### PR TITLE
Refactor prompt model to remove unused Contract import

### DIFF
--- a/src/model/prompt.rs
+++ b/src/model/prompt.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-use super::contract::Contract;
 
 /// The internal Prompt representation used during Phase 3 generation.
 /// This model acts strictly down-stream from contracts; it is not a parallel source of truth.


### PR DESCRIPTION
もともと実装されていたため、リファクタリングして終了します。

#28 