### PR TITLE
fix: Fix unbound variable issue and update release workflow

### DIFF
--- a/.github/workflows/archflow-release-cli.yml
+++ b/.github/workflows/archflow-release-cli.yml
@@ -204,80 +204,13 @@ jobs:
           name: archflow-release-aarch64-apple-darwin
           path: dist/*
 
-  build-macos-arm64-fallback:
-    name: Build (aarch64-apple-darwin fallback macos-14)
-    runs-on: macos-14
-    timeout-minutes: 60
-    needs: build-macos-arm64-primary
-    if: needs.build-macos-arm64-primary.result == 'failure'
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Resolve release tag
-        id: release_tag
-        shell: bash
-        run: |
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "value=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Validate release tag format
-        shell: bash
-        run: |
-          TAG="${{ steps.release_tag.outputs.value }}"
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid tag format: $TAG (expected vX.Y.Z)" >&2
-            exit 1
-          fi
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-darwin
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-
-      - name: Build release binary
-        run: cargo build --release --target aarch64-apple-darwin
-
-      - name: Skip smoke test for cross target
-        run: echo "Skipping runtime smoke test for cross-compiled target aarch64-apple-darwin"
-
-      - name: Package archive
-        shell: bash
-        run: |
-          TAG="${{ steps.release_tag.outputs.value }}"
-          TARGET_ROOT="${CARGO_TARGET_DIR:-target}"
-          DIST_DIR="dist"
-          mkdir -p "$DIST_DIR"
-          ARCHIVE_NAME="archflow-${TAG}-aarch64-apple-darwin.tar.gz"
-          tar -czf "$DIST_DIR/$ARCHIVE_NAME" -C "${TARGET_ROOT}/aarch64-apple-darwin/release" "archflow"
-
-          (cd "$DIST_DIR" && sha256sum "$ARCHIVE_NAME" > "$ARCHIVE_NAME.sha256")
-
-      - name: Upload release artifact bundle
-        uses: actions/upload-artifact@v4
-        with:
-          name: archflow-release-aarch64-apple-darwin
-          path: dist/*
-          overwrite: true
-
   publish:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
     needs:
       - build
       - build-macos-arm64-primary
-      - build-macos-arm64-fallback
-    if: |
-      always() &&
-      needs.build.result == 'success' &&
-      (needs.build-macos-arm64-primary.result == 'success' || needs.build-macos-arm64-fallback.result == 'success')
+    if: needs.build.result == 'success' && needs.build-macos-arm64-primary.result == 'success'
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -80,10 +80,12 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: sync version with release drafter"
-          title: "chore: sync version with release drafter"
+          commit-message: "chore: sync version to v${{ steps.drafter.outputs.resolved_version }} with release drafter"
+          title: "chore: sync version to v${{ steps.drafter.outputs.resolved_version }} with release drafter"
           body: |
             Automated version synchronization generated from release-drafter resolved version.
+
+            Target version: `v${{ steps.drafter.outputs.resolved_version }}`
 
             - Updates `Cargo.toml` version
             - Updates root package version in `Cargo.lock`

--- a/scripts/install-archflow.sh
+++ b/scripts/install-archflow.sh
@@ -5,6 +5,13 @@ REPO_OWNER="Arcflect"
 REPO_NAME="archflow"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 REQUESTED_VERSION="${1:-latest}"
+TMP_DIR=""
+
+cleanup_tmp_dir() {
+  if [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
 
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -135,25 +142,24 @@ main() {
   checksum_name="${archive_name}.sha256"
   base_url="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${version}"
 
-  local tmp_dir
-  tmp_dir="$(mktemp -d)"
-  trap 'rm -rf "$tmp_dir"' EXIT
+  TMP_DIR="$(mktemp -d)"
+  trap cleanup_tmp_dir EXIT
 
   echo "downloading ${archive_name}"
-  curl -fsSL -o "$tmp_dir/$archive_name" "$base_url/$archive_name"
-  curl -fsSL -o "$tmp_dir/$checksum_name" "$base_url/$checksum_name"
+  curl -fsSL -o "$TMP_DIR/$archive_name" "$base_url/$archive_name"
+  curl -fsSL -o "$TMP_DIR/$checksum_name" "$base_url/$checksum_name"
 
   echo "verifying checksum"
-  (cd "$tmp_dir" && verify_checksum "$archive_name" "$checksum_name")
+  (cd "$TMP_DIR" && verify_checksum "$archive_name" "$checksum_name")
 
-  tar -xzf "$tmp_dir/$archive_name" -C "$tmp_dir"
+  tar -xzf "$TMP_DIR/$archive_name" -C "$TMP_DIR"
 
-  if [[ ! -f "$tmp_dir/archflow" ]]; then
+  if [[ ! -f "$TMP_DIR/archflow" ]]; then
     echo "archive does not contain expected binary: archflow" >&2
     exit 1
   fi
 
-  install_binary "$tmp_dir/archflow"
+  install_binary "$TMP_DIR/archflow"
   archflow --version
 }
 


### PR DESCRIPTION
This pull request contains several workflow and script improvements, primarily focused on build reliability, artifact handling, and version synchronization. The most significant changes are the removal of a fallback macOS build job, enhancements to the release drafter workflow, and improvements to the installation script's temporary directory management.

**CI/CD Workflow Improvements:**

* Removed the `build-macos-arm64-fallback` job from `.github/workflows/archflow-release-cli.yml`, simplifying the build process and making the `publish` job depend solely on the success of the primary macOS ARM64 build. This reduces complexity and ensures that only successful primary builds are published.
* Updated the `publish` job's conditions to only proceed if both the main build and the primary macOS ARM64 build succeed, removing fallback logic.

**Release Drafter Workflow Enhancements:**

* Improved the commit message and PR title in `.github/workflows/release-drafter.yml` to include the resolved version, making automated version synchronization PRs more descriptive and traceable.

**Installation Script Reliability:**

* Refactored `scripts/install-archflow.sh` to use a global `TMP_DIR` with a dedicated `cleanup_tmp_dir` function, ensuring temporary files are always cleaned up and improving script reliability. [[1]](diffhunk://#diff-0e0815b1f7e855cb85c3deb18024255d81b9b79066791ba0c57274d9828de9f2R8-R14) [[2]](diffhunk://#diff-0e0815b1f7e855cb85c3deb18024255d81b9b79066791ba0c57274d9828de9f2L138-R162)