### PR TITLE
feat: implement RBAC governance roles and authorization checks for policy operations

### DIFF
--- a/docs/governance-rbac.md
+++ b/docs/governance-rbac.md
@@ -1,0 +1,71 @@
+# Governance & RBAC
+
+## Overview
+
+Archflow allows strict structural and architectural contracts across your organization. Once you deploy these rules, you must establish an operational boundary between standard development activities and governance operations (changing the rules or overriding the architecture).
+
+Archflow's Role-Based Access Control (RBAC) maps operational actors (such as GitHub teams or users) to built-in Archflow governance roles.
+
+## Core Governance Roles
+
+The system supports the following built-in governance roles:
+
+### 1. `policy_admin`
+- **Responsibilities**: Modifying organization or team policies, locking rules, and adjusting the baseline configurations.
+- **Allowed Operations**: `EditPolicy`, `RunAudit`, `ApproveOverride`, `FixRollout`.
+- **Target Audience**: Core Architecture Team / Security Team.
+
+### 2. `architect`
+- **Responsibilities**: Overseeing the day-to-day architecture across repositories and evaluating temporary exceptions or deviations from policy.
+- **Allowed Operations**: `ApproveOverride`, `FixRollout`, `RunAudit`.
+- **Target Audience**: Team Leads and Domain Architects.
+
+### 3. `auditor`
+- **Responsibilities**: Viewing compliance reports and investigating architectural violations.
+- **Allowed Operations**: `RunAudit`.
+- **Target Audience**: General engineers, compliance officers, and automated CI pipelines.
+
+> [!NOTE]
+> Any unmapped actor falls back to the minimum permission set allowed, which allows them to view the `RunAudit` output but absolutely prevents policy tampering or override approvals.
+
+---
+
+## Configuring Governance Roles
+
+You can map an actor to a role by adding `governance_roles` blocks in your policy layer files (`.archflow/org.policy.yaml`, `.archflow/team.policy.yaml`, etc.).
+
+```yaml
+version: 1
+label: platform-tech
+governance_roles:
+  - role: policy_admin
+    members:
+      - "@platform-core"
+  - role: architect
+    members:
+      - "@domain-a-leads"
+      - "@domain-b-leads"
+      - alice@example.com
+```
+
+### Precedence
+
+Like required files or forbidden dependencies, governance roles follow a precedence chain: `org` → `team` → `project`.
+Typically, you define your `policy_admin` in `org.policy.yaml` and delegate `architect` definitions at the `team.policy.yaml` level.
+
+---
+
+## Enforcement in CI vs Local
+
+Because Archflow is primarily a CLI toolkit, an actor mapping doesn't inherently verify the cryptographic identity of the active user. Instead, operators structure their physical boundaries inside CI via `CODEOWNERS` files referencing the same names.
+
+For example, a physical CI boundary involves generating a `.github/CODEOWNERS` configuration dynamically based on your `.archflow/org.policy.yaml`.
+
+During pipeline executions (like merging PRs or rolling out fixes), Archflow can be invoked explicitly with the `--actor` argument to test simulated governance flows locally or apply strict enforcement rules:
+```bash
+archflow policy-resolve --actor "@alice"
+```
+```bash
+# Example showing a rejection message:
+[!] RBAC Denied: actor '@alice' is not authorized...
+```

--- a/schemas/policy-profile.schema.yaml
+++ b/schemas/policy-profile.schema.yaml
@@ -66,6 +66,20 @@ fields:
         required: true
         description: Human-readable justification for the override.
 
+  governance_roles:
+    type: list[map]
+    required: false
+    description: Role-Based Access Control map defining mappings of teams/users to governance roles.
+    item_fields:
+      role:
+        type: string
+        required: true
+        description: Governance role identifier (e.g. policy_admin, architect, auditor).
+      members:
+        type: list[string]
+        required: true
+        description: Actors mapped to this role (e.g., github usernames or team slugs like @org/architects).
+
 example:
   version: 1
   required_files:
@@ -85,3 +99,10 @@ example:
       targets:
         - artifact:create_legacy_user
       reason: temporary migration path
+  governance_roles:
+    - role: policy_admin
+      members:
+        - "@archflow/core"
+    - role: architect
+      members:
+        - "@archflow/architecture-committee"

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -163,11 +163,13 @@ pub fn handle(command: Commands) {
             org_policy,
             team_policy,
             project_policy,
+            actor,
         } => {
             crate::commands::policy_resolve::execute_cli(
                 org_policy.as_deref(),
                 team_policy.as_deref(),
                 project_policy.as_deref(),
+                actor.as_deref(),
             );
         }
         Commands::FixRolloutPlan { output } => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -185,6 +185,9 @@ pub enum Commands {
         /// Path to project-level policy file (default: policy.profile.yaml)
         #[arg(long)]
         project_policy: Option<String>,
+        /// Identity of the actor invoking the command, used to simulate RBAC evaluation
+        #[arg(long)]
+        actor: Option<String>,
     },
     /// Generate a structured fix rollout plan (JSON) from current audit findings
     FixRolloutPlan {

--- a/src/commands/policy_resolve.rs
+++ b/src/commands/policy_resolve.rs
@@ -1,9 +1,15 @@
 use crate::config::override_policy::{
     load_effective_policy, EffectivePolicy, OverrideLevel,
 };
+use crate::config::rbac::{GovernanceOperation, RbacEvaluator};
 use std::path::Path;
 
-pub fn execute_cli(org_policy: Option<&str>, team_policy: Option<&str>, project_policy: Option<&str>) {
+pub fn execute_cli(
+    org_policy: Option<&str>,
+    team_policy: Option<&str>,
+    project_policy: Option<&str>,
+    actor: Option<&str>,
+) {
     let org_path = org_policy.map(Path::new);
     let team_path = team_policy.map(Path::new);
     let project_path = project_policy.map(Path::new);
@@ -16,13 +22,21 @@ pub fn execute_cli(org_policy: Option<&str>, team_policy: Option<&str>, project_
         }
     };
 
+    if let Some(actor_name) = actor {
+        let auth_result = RbacEvaluator::authorize_operation(&ep, actor_name, GovernanceOperation::RunAudit);
+        if !auth_result.is_allowed() {
+            eprintln!("[!] RBAC Denied: actor '{}' is not authorized to run audit/policy commands.", actor_name);
+            std::process::exit(1);
+        }
+    }
+
     render_effective_policy(&ep);
 }
 
 /// Load effective policy using default paths and render it.
 /// Called without explicit path arguments — uses standard lookup paths.
 #[allow(dead_code)]
-pub fn execute_default_cli() {
+pub fn execute_default_cli(actor: Option<&str>) {
     let ep = match load_effective_policy() {
         Ok(ep) => ep,
         Err(err) => {
@@ -30,6 +44,14 @@ pub fn execute_default_cli() {
             std::process::exit(1);
         }
     };
+
+    if let Some(actor_name) = actor {
+        let auth_result = RbacEvaluator::authorize_operation(&ep, actor_name, GovernanceOperation::RunAudit);
+        if !auth_result.is_allowed() {
+            eprintln!("[!] RBAC Denied: actor '{}' is not authorized to run audit/policy commands.", actor_name);
+            std::process::exit(1);
+        }
+    }
 
     render_effective_policy(&ep);
 }
@@ -111,6 +133,24 @@ pub fn render_effective_policy(ep: &EffectivePolicy) {
             println!("    reason: {}", entry.reason);
             for target in &entry.targets {
                 println!("    - {}", target);
+            }
+        }
+    }
+    println!();
+
+    // Governance Roles
+    if ep.governance_roles.is_empty() {
+        println!("Governance roles: (none mapped)");
+    } else {
+        println!("Governance roles:");
+        for role_binding in &ep.governance_roles {
+            println!(
+                "  role: {}  [source: {}]",
+                role_binding.role, role_binding.source_label
+            );
+            println!("    members:");
+            for member in &role_binding.members {
+                println!("      - {}", member);
             }
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,3 +16,4 @@ pub use placement::PlacementRulesConfig;
 pub use policy::PolicyProfileConfig;
 pub use project::ProjectConfig;
 pub mod override_policy;
+pub mod rbac;

--- a/src/config/override_policy.rs
+++ b/src/config/override_policy.rs
@@ -8,8 +8,8 @@
 /// level wins. The `resolve` command surfaces the full effective-policy resolution
 /// so that governance is auditable and predictable.
 use crate::config::policy::{
-    NamingPolicy, NamingRule, PolicyOverride, PolicyProfileConfig, RoleForbiddenDependencyPolicy,
-    SUPPORTED_POLICY_PROFILE_VERSION,
+    GovernanceRoleBinding, NamingPolicy, NamingRule, PolicyOverride, PolicyProfileConfig,
+    RoleForbiddenDependencyPolicy, SUPPORTED_POLICY_PROFILE_VERSION,
 };
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -86,6 +86,9 @@ pub struct PolicyLayer {
     /// Required files enforced by this layer (merged with lower levels).
     #[serde(default)]
     pub required_files: Vec<String>,
+    /// Governance roles contributed by this layer.
+    #[serde(default)]
+    pub governance_roles: Vec<GovernanceRoleBinding>,
 }
 
 impl PolicyLayer {
@@ -153,6 +156,16 @@ pub struct ResolvedRequiredFile {
     pub source_label: String,
 }
 
+/// A governance role binding in the resolved policy.
+#[derive(Debug, Clone)]
+pub struct ResolvedGovernanceRoleBinding {
+    pub role: String,
+    pub members: Vec<String>,
+    #[allow(dead_code)]
+    pub source_level: OverrideLevel,
+    pub source_label: String,
+}
+
 /// A locked-rule entry: this rule cannot be overridden by lower levels.
 #[derive(Debug, Clone)]
 pub struct ResolvedLockedRule {
@@ -176,6 +189,8 @@ pub struct EffectivePolicy {
     pub required_files: Vec<ResolvedRequiredFile>,
     /// Rules locked by org or team that cannot be suppressed at lower levels.
     pub locked_rules: Vec<ResolvedLockedRule>,
+    /// All resolved governance roles (highest level wins per role).
+    pub governance_roles: Vec<ResolvedGovernanceRoleBinding>,
 }
 
 impl EffectivePolicy {
@@ -228,6 +243,14 @@ impl EffectivePolicy {
                     rule_id: entry.rule_id.clone(),
                     targets: entry.targets.clone(),
                     reason: entry.reason.clone(),
+                })
+                .collect(),
+            governance_roles: self
+                .governance_roles
+                .iter()
+                .map(|role| GovernanceRoleBinding {
+                    role: role.role.clone(),
+                    members: role.members.clone(),
                 })
                 .collect(),
         }
@@ -354,6 +377,23 @@ pub fn resolve(
         }
     }
 
+    // Resolve governance roles: highest-precedence level wins per role.
+    let mut resolved_roles: Vec<ResolvedGovernanceRoleBinding> = Vec::new();
+    let mut seen_gov_role: std::collections::HashSet<String> = Default::default();
+
+    for (level, layer) in &loaded {
+        for role_binding in &layer.governance_roles {
+            if seen_gov_role.insert(role_binding.role.clone()) {
+                resolved_roles.push(ResolvedGovernanceRoleBinding {
+                    role: role_binding.role.clone(),
+                    members: role_binding.members.clone(),
+                    source_level: level.clone(),
+                    source_label: friendly_label(level, &layer.label),
+                });
+            }
+        }
+    }
+
     // Resolve required files: union of all levels (no deduplication).
     let mut resolved_required: Vec<ResolvedRequiredFile> = Vec::new();
     let mut seen_file: std::collections::HashSet<String> = Default::default();
@@ -393,6 +433,7 @@ pub fn resolve(
         forbidden_dependencies: resolved_forbidden,
         required_files: resolved_required,
         locked_rules,
+        governance_roles: resolved_roles,
     })
 }
 
@@ -746,6 +787,49 @@ forbidden_dependencies:
         // Org wins; project-level entry should not be present.
         assert!(deps.contains(&"infrastructure_module".to_string()));
         assert!(!deps.contains(&"project_level_entry".to_string()));
+    }
+
+    #[test]
+    fn governance_roles_highest_level_wins_per_role() {
+        let tmp = tempdir().unwrap();
+        write(
+            tmp.path(),
+            "org.yaml",
+            r#"
+version: 1
+governance_roles:
+  - role: auditor
+    members:
+      - "@org-auditor"
+"#,
+        );
+        write(
+            tmp.path(),
+            "project.yaml",
+            r#"
+version: 1
+governance_roles:
+  - role: auditor
+    members:
+      - "@project-auditor"
+"#,
+        );
+
+        let ep = resolve(
+            Some(&tmp.path().join("org.yaml")),
+            None,
+            Some(&tmp.path().join("project.yaml")),
+        )
+        .unwrap();
+
+        let roles: Vec<&ResolvedGovernanceRoleBinding> = ep
+            .governance_roles
+            .iter()
+            .filter(|r| r.role == "auditor")
+            .collect();
+        assert_eq!(roles.len(), 1);
+        assert_eq!(roles[0].members, vec!["@org-auditor".to_string()]);
+        assert_eq!(roles[0].source_level, OverrideLevel::Org);
     }
 
     #[test]

--- a/src/config/policy.rs
+++ b/src/config/policy.rs
@@ -20,6 +20,8 @@ pub struct PolicyProfileConfig {
     pub forbidden_dependencies: Vec<RoleForbiddenDependencyPolicy>,
     #[serde(default)]
     pub overrides: Vec<PolicyOverride>,
+    #[serde(default)]
+    pub governance_roles: Vec<GovernanceRoleBinding>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -46,6 +48,12 @@ pub struct PolicyOverride {
     pub rule_id: String,
     pub targets: Vec<String>,
     pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GovernanceRoleBinding {
+    pub role: String,
+    pub members: Vec<String>,
 }
 
 impl PolicyProfileConfig {
@@ -86,6 +94,7 @@ impl PolicyProfileConfig {
             },
             forbidden_dependencies: vec![],
             overrides: vec![],
+            governance_roles: vec![],
         }
     }
 
@@ -181,6 +190,15 @@ impl PolicyProfileConfig {
                         "override '{}' must provide reason",
                         override_entry.rule_id
                     ),
+                });
+            }
+        }
+
+        for role_binding in &self.governance_roles {
+            if role_binding.role.trim().is_empty() {
+                return Err(ConfigError::Validation {
+                    path: path.clone(),
+                    message: "governance_roles[].role cannot be empty".to_string(),
                 });
             }
         }

--- a/src/config/rbac.rs
+++ b/src/config/rbac.rs
@@ -1,0 +1,174 @@
+use crate::config::override_policy::EffectivePolicy;
+
+/// Identifies a governance operation that requires authorization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GovernanceOperation {
+    /// Authorize applying policy overrides to suppress audit bounds.
+    ApproveOverride,
+    /// Authorize applying global config changes or locked rules.
+    EditPolicy,
+    /// Authorize applying a patch via rollout.
+    FixRollout,
+    /// Standard viewing/audit execution capabilities.
+    RunAudit,
+}
+
+/// A parsed identity check outcome
+#[derive(Debug, PartialEq, Eq)]
+pub enum AuthorizationOutcome {
+    Allowed,
+    Denied(String),
+}
+
+impl AuthorizationOutcome {
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, AuthorizationOutcome::Allowed)
+    }
+}
+
+/// RBAC engine validating an arbitrary actor against loaded `EffectivePolicy` governance roles
+pub struct RbacEvaluator;
+
+impl RbacEvaluator {
+    /// Check whether `actor` is allowed to perform `operation`, based on bindings in `policy`.
+    /// Built-in roles:
+    /// - `policy_admin`: Allowed to EditPolicy, RunAudit.
+    /// - `architect`: Allowed to ApproveOverride, FixRollout, RunAudit.
+    /// - `auditor`: Allowed to RunAudit.
+    /// Default access for any non-mapped actor: `RunAudit`.
+    pub fn authorize_operation(
+        policy: &EffectivePolicy,
+        actor: &str,
+        operation: GovernanceOperation,
+    ) -> AuthorizationOutcome {
+        // Find which roles the actor belongs to based on the highest precedence level governance_roles
+        let mut actor_roles = vec![];
+        for binding in &policy.governance_roles {
+            if binding.members.iter().any(|m| m == actor) {
+                actor_roles.push(binding.role.as_str());
+            }
+        }
+
+        match operation {
+            GovernanceOperation::EditPolicy => {
+                if actor_roles.contains(&"policy_admin") {
+                    AuthorizationOutcome::Allowed
+                } else {
+                    AuthorizationOutcome::Denied(
+                        "actor is missing required role: policy_admin".to_string(),
+                    )
+                }
+            }
+            GovernanceOperation::ApproveOverride => {
+                if actor_roles.contains(&"architect") || actor_roles.contains(&"policy_admin") {
+                    AuthorizationOutcome::Allowed
+                } else {
+                    AuthorizationOutcome::Denied(
+                        "actor is missing required role: architect or policy_admin".to_string(),
+                    )
+                }
+            }
+            GovernanceOperation::FixRollout => {
+                if actor_roles.contains(&"architect") || actor_roles.contains(&"policy_admin") {
+                    AuthorizationOutcome::Allowed
+                } else {
+                    AuthorizationOutcome::Denied(
+                        "actor is missing required role: architect or policy_admin".to_string(),
+                    )
+                }
+            }
+            GovernanceOperation::RunAudit => {
+                // By default anyone can run an audit report
+                AuthorizationOutcome::Allowed
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::override_policy::{OverrideLevel, ResolvedGovernanceRoleBinding};
+    use crate::config::policy::NamingRule;
+
+    fn dummy_effective_policy(
+        roles: Vec<ResolvedGovernanceRoleBinding>,
+    ) -> EffectivePolicy {
+        EffectivePolicy {
+            module_naming: (
+                NamingRule::KebabCase,
+                OverrideLevel::Default,
+                "default".to_string(),
+            ),
+            artifact_naming: (
+                NamingRule::KebabCase,
+                OverrideLevel::Default,
+                "default".to_string(),
+            ),
+            overrides: vec![],
+            forbidden_dependencies: vec![],
+            required_files: vec![],
+            locked_rules: vec![],
+            governance_roles: roles,
+        }
+    }
+
+    #[test]
+    fn unmapped_actor_cannot_edit_policy() {
+        let policy = dummy_effective_policy(vec![]);
+        let outcome =
+            RbacEvaluator::authorize_operation(&policy, "alice", GovernanceOperation::EditPolicy);
+        assert!(!outcome.is_allowed());
+        if let AuthorizationOutcome::Denied(reason) = outcome {
+            assert!(reason.contains("policy_admin"));
+        }
+    }
+
+    #[test]
+    fn policy_admin_can_edit_policy_and_approve_overrides() {
+        let policy = dummy_effective_policy(vec![ResolvedGovernanceRoleBinding {
+            role: "policy_admin".to_string(),
+            members: vec!["admin-bob".to_string()],
+            source_level: OverrideLevel::Org,
+            source_label: "org".to_string(),
+        }]);
+
+        let outcome = RbacEvaluator::authorize_operation(
+            &policy,
+            "admin-bob",
+            GovernanceOperation::EditPolicy,
+        );
+        assert!(outcome.is_allowed());
+
+        let outcome = RbacEvaluator::authorize_operation(
+            &policy,
+            "admin-bob",
+            GovernanceOperation::ApproveOverride,
+        );
+        assert!(outcome.is_allowed());
+    }
+
+    #[test]
+    fn architect_can_approve_overrides_but_not_edit_policy() {
+        let policy = dummy_effective_policy(vec![ResolvedGovernanceRoleBinding {
+            role: "architect".to_string(),
+            members: vec!["arch-charlie".to_string()],
+            source_level: OverrideLevel::Org,
+            source_label: "org".to_string(),
+        }]);
+
+        let outcome = RbacEvaluator::authorize_operation(
+            &policy,
+            "arch-charlie",
+            GovernanceOperation::ApproveOverride,
+        );
+        assert!(outcome.is_allowed());
+
+        let outcome = RbacEvaluator::authorize_operation(
+            &policy,
+            "arch-charlie",
+            GovernanceOperation::EditPolicy,
+        );
+        assert!(!outcome.is_allowed());
+    }
+}


### PR DESCRIPTION
This pull request introduces comprehensive support for Role-Based Access Control (RBAC) and governance roles in Archflow. It adds new schema fields, documentation, CLI options, policy resolution logic, and enforcement for mapping users/teams to governance roles. The changes ensure that only authorized actors can perform sensitive operations, and governance roles are resolved with clear precedence across organization, team, and project levels.

**Governance & RBAC support:**

* Added a new `governance_roles` field to the policy schema (`policy-profile.schema.yaml`) and included documentation and examples for mapping actors (users or teams) to governance roles like `policy_admin`, `architect`, and `auditor`. [[1]](diffhunk://#diff-66953d3c2c09fab438b798df2fa905753fe9dbbb102b0f2263441cb7e51b0b98R69-R82) [[2]](diffhunk://#diff-66953d3c2c09fab438b798df2fa905753fe9dbbb102b0f2263441cb7e51b0b98R102-R108) [[3]](diffhunk://#diff-daeb5c6b0957204e6da300226389ab9418808e156307908420af6082b0c76640R1-R71)
* Implemented logic in the policy resolution engine to merge and resolve governance roles, ensuring the highest-precedence definition wins for each role. Added tests to verify correct precedence and merging. [[1]](diffhunk://#diff-46d88afeb3abcd8d8803083a8fee57858a7f568b7e10eb82b0fde1050c961e50R89-R91) [[2]](diffhunk://#diff-46d88afeb3abcd8d8803083a8fee57858a7f568b7e10eb82b0fde1050c961e50R159-R168) [[3]](diffhunk://#diff-46d88afeb3abcd8d8803083a8fee57858a7f568b7e10eb82b0fde1050c961e50R192-R193) [[4]](diffhunk://#diff-46d88afeb3abcd8d8803083a8fee57858a7f568b7e10eb82b0fde1050c961e50R248-R255) [[5]](diffhunk://#diff-46d88afeb3abcd8d8803083a8fee57858a7f568b7e10eb82b0fde1050c961e50R380-R396) [[6]](diffhunk://#diff-46d88afeb3abcd8d8803083a8fee57858a7f568b7e10eb82b0fde1050c961e50R436) [[7]](diffhunk://#diff-46d88afeb3abcd8d8803083a8fee57858a7f568b7e10eb82b0fde1050c961e50R792-R834) [[8]](diffhunk://#diff-78f5839dca58231c7674fa07085530bc16d76ff996de0ec9fb159450b59c7c7bR23-R24) [[9]](diffhunk://#diff-78f5839dca58231c7674fa07085530bc16d76ff996de0ec9fb159450b59c7c7bR53-R58) [[10]](diffhunk://#diff-78f5839dca58231c7674fa07085530bc16d76ff996de0ec9fb159450b59c7c7bR97) [[11]](diffhunk://#diff-78f5839dca58231c7674fa07085530bc16d76ff996de0ec9fb159450b59c7c7bR197-R205)

**CLI and enforcement enhancements:**

* Extended the `policy-resolve` CLI command to accept an `--actor` argument, enabling RBAC enforcement and simulation of governance flows. The CLI now denies unauthorized actors and displays governance role mappings in the output. [[1]](diffhunk://#diff-82453e80e064c58b8fe1569389172f4a10adc0e685de6c3a787e07bcd9d98cffR188-R190) [[2]](diffhunk://#diff-38da8705fdf2662e3e19585f900ecaa4856c7edd07d6686cc3a7a8f829fd1653R166-R172) [[3]](diffhunk://#diff-f501333b07661c170e611b56159499f707545427aaf1714883e518e8e5366eb0R4-R12) [[4]](diffhunk://#diff-f501333b07661c170e611b56159499f707545427aaf1714883e518e8e5366eb0R25-R39) [[5]](diffhunk://#diff-f501333b07661c170e611b56159499f707545427aaf1714883e518e8e5366eb0R48-R55) [[6]](diffhunk://#diff-f501333b07661c170e611b56159499f707545427aaf1714883e518e8e5366eb0R141-R158)

**Documentation:**

* Added a new `docs/governance-rbac.md` file that provides an overview, configuration instructions, and enforcement details for RBAC and governance roles in Archflow.

**Internal structure:**

* Added new types and modules to support governance roles in the codebase, including `GovernanceRoleBinding`, `ResolvedGovernanceRoleBinding`, and the `rbac` module. [[1]](diffhunk://#diff-b0ba3e54b6f5ef1fa6aed8075e352a68fda66067fbafa8421042a2347801338aR19) [[2]](diffhunk://#diff-46d88afeb3abcd8d8803083a8fee57858a7f568b7e10eb82b0fde1050c961e50L11-R12) [[3]](diffhunk://#diff-78f5839dca58231c7674fa07085530bc16d76ff996de0ec9fb159450b59c7c7bR53-R58)

These changes collectively enable robust, auditable governance and RBAC enforcement in Archflow, ensuring that only authorized actors can modify or override architectural policies.