### PR TITLE
feat: implement expiration support for policy overrides with validation and audit enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +71,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 name = "archflow"
 version = "1.2.0"
 dependencies = [
+ "chrono",
  "clap",
  "serde",
  "serde_json",
@@ -71,16 +81,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -129,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +200,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -191,6 +248,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +302,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +340,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -308,6 +408,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -376,6 +482,12 @@ dependencies = [
  "serde",
  "unsafe-libyaml",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "strsim"
@@ -470,6 +582,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,10 +661,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
+chrono = "0.4"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/docs/governance-exceptions.md
+++ b/docs/governance-exceptions.md
@@ -1,0 +1,44 @@
+# Policy Exception Lifecycle
+
+## Overview
+
+In enterprise environments, enforcing a strict architectural policy is critical to avoiding structural degradation. However, enforcing rigid boundaries can often block critical hotfixes or migration paths.
+
+Archflow manages this reality through **Policy Overrides**. To prevent these overrides from becoming permanent technical debt, Archflow supports an exception lifecycle bound by strict expiration dates (`expires_at`). 
+
+## Managing Overrides
+
+Overrides allow architects to temporarily suppress specific rules against specific targets, preventing them from failing mechanical CI `archflow audit` checks. 
+
+### Adding an Expiration Date
+
+Whenever an override is introduced in an org, team, or project level policy (`.archflow/org.policy.yaml`, `policy.profile.yaml`, etc.), operators should define an `expires_at` date using the standard ISO 8601 (`YYYY-MM-DD`) format.
+
+```yaml
+version: 1
+overrides:
+  - rule_id: artifact-module-defined
+    targets:
+      - artifact:legacy_auth_service
+    reason: "Pending migration to the new identity module. Sprint 42 deliverable."
+    expires_at: "2026-12-31"
+```
+
+### Expiration Behavior
+
+The Archflow core resolution engine parses the expiration date against the current UTC date when loading policies.
+
+- **Active Overrides**: If the current date is *before or equal* to the `expires_at` date, the override suppresses the audit rule. 
+- **Expired Overrides**: If the current date is *after* the `expires_at` date, Archflow structurally discards the override from its resolution. The audit rule immediately resurfaces.
+  - Expired overrides are visibly tagged with `[EXPIRED]` when diagnosing policies using `archflow policy-resolve`.
+  - Next time `archflow audit` runs in CI, the build will break securely, forcing the team to address the structural debt or renegotiate the architectural contract.
+
+## Workflow Integration
+
+We recommend the following flow for governance teams (members defined as `architect` or `policy_admin` in your RBAC configurations):
+
+1. **Issue Identified**: `archflow audit` blocks a pull request due to an architectural deviation.
+2. **Review & Negotiation**: The team submits a pull request proposing a temporary override in `policy.profile.yaml` setting `expires_at` to the expected remediation date.
+3. **Approval**: An `architect` explicitly approves the override using `archflow fix-rollout-approve` or direct pull request review.
+4. **Resolution**: The team removes the deviation inside the expiration timeframe and cleans up the override.
+5. **Expiration Trap**: If forgotten, `archflow audit` ensures the system fails safe immediately upon the expiration boundary.

--- a/schemas/policy-profile.schema.yaml
+++ b/schemas/policy-profile.schema.yaml
@@ -65,6 +65,10 @@ fields:
         type: string
         required: true
         description: Human-readable justification for the override.
+      expires_at:
+        type: string
+        required: false
+        description: ISO 8601 date (YYYY-MM-DD) indicating when this override expires. If expired, it structurally drops out of the effective policy.
 
   governance_roles:
     type: list[map]
@@ -99,6 +103,7 @@ example:
       targets:
         - artifact:create_legacy_user
       reason: temporary migration path
+      expires_at: "2026-12-31"
   governance_roles:
     - role: policy_admin
       members:

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -543,6 +543,7 @@ mod tests {
             rule_id: "artifact-module-defined".to_string(),
             targets: vec!["artifact:create_order".to_string()],
             reason: "legacy migration".to_string(),
+            expires_at: None,
         });
         let artifacts = ArtifactsPlanConfig {
             artifacts: vec![Artifact {

--- a/src/commands/policy_resolve.rs
+++ b/src/commands/policy_resolve.rs
@@ -126,11 +126,15 @@ pub fn render_effective_policy(ep: &EffectivePolicy) {
     } else {
         println!("Overrides:");
         for entry in &ep.overrides {
+            let expired_tag = if entry.is_expired { " [EXPIRED]" } else { "" };
             println!(
-                "  rule: {}  [source: {}]",
-                entry.rule_id, entry.source_label
+                "  rule: {}{}  [source: {}]",
+                entry.rule_id, expired_tag, entry.source_label
             );
             println!("    reason: {}", entry.reason);
+            if let Some(exp) = &entry.expires_at {
+                println!("    expires at: {}", exp);
+            }
             for target in &entry.targets {
                 println!("    - {}", target);
             }

--- a/src/config/override_policy.rs
+++ b/src/config/override_policy.rs
@@ -132,6 +132,8 @@ pub struct ResolvedOverride {
     pub rule_id: String,
     pub targets: Vec<String>,
     pub reason: String,
+    pub expires_at: Option<String>,
+    pub is_expired: bool,
     #[allow(dead_code)]
     pub source_level: OverrideLevel,
     pub source_label: String,
@@ -207,7 +209,8 @@ impl EffectivePolicy {
     #[allow(dead_code)]
     pub fn is_overridden(&self, rule_id: &str, target: &str) -> bool {
         self.overrides.iter().any(|entry| {
-            entry.rule_id == rule_id
+            !entry.is_expired
+                && entry.rule_id == rule_id
                 && entry.targets.iter().any(|candidate| candidate == target)
         })
     }
@@ -243,6 +246,7 @@ impl EffectivePolicy {
                     rule_id: entry.rule_id.clone(),
                     targets: entry.targets.clone(),
                     reason: entry.reason.clone(),
+                    expires_at: entry.expires_at.clone(),
                 })
                 .collect(),
             governance_roles: self
@@ -349,10 +353,22 @@ pub fn resolve(
                 }
             }
             if !new_targets.is_empty() {
+                let mut is_expired = false;
+                if let Some(expires_at) = &entry.expires_at {
+                    if let Ok(expiration_date) = chrono::NaiveDate::parse_from_str(expires_at, "%Y-%m-%d") {
+                        let today = chrono::Utc::now().naive_utc().date();
+                        if expiration_date < today {
+                            is_expired = true;
+                        }
+                    }
+                }
+
                 resolved_overrides.push(ResolvedOverride {
                     rule_id: entry.rule_id.clone(),
                     targets: new_targets,
                     reason: entry.reason.clone(),
+                    expires_at: entry.expires_at.clone(),
+                    is_expired,
                     source_level: level.clone(),
                     source_label: friendly_label(level, &layer.label),
                 });
@@ -830,6 +846,45 @@ governance_roles:
         assert_eq!(roles.len(), 1);
         assert_eq!(roles[0].members, vec!["@org-auditor".to_string()]);
         assert_eq!(roles[0].source_level, OverrideLevel::Org);
+    }
+
+    #[test]
+    fn override_is_ignored_when_expired() {
+        let tmp = tempdir().unwrap();
+        write(
+            tmp.path(),
+            "project.yaml",
+            r#"
+version: 1
+overrides:
+  - rule_id: expiring-rule
+    targets: ["some.yml"]
+    reason: "testing"
+    expires_at: "2010-01-01"
+"#,
+        );
+        let ep = resolve(None, None, Some(&tmp.path().join("project.yaml"))).unwrap();
+        assert!(!ep.is_overridden("expiring-rule", "some.yml"), "Expired override should not be actively applied");
+    }
+
+    #[test]
+    fn override_is_applied_when_not_expired() {
+        let tmp = tempdir().unwrap();
+        // Use a far future date
+        write(
+            tmp.path(),
+            "project.yaml",
+            r#"
+version: 1
+overrides:
+  - rule_id: expiring-rule
+    targets: ["some.yml"]
+    reason: "testing"
+    expires_at: "2099-01-01"
+"#,
+        );
+        let ep = resolve(None, None, Some(&tmp.path().join("project.yaml"))).unwrap();
+        assert!(ep.is_overridden("expiring-rule", "some.yml"), "Active override should be applied");
     }
 
     #[test]

--- a/src/config/policy.rs
+++ b/src/config/policy.rs
@@ -48,6 +48,8 @@ pub struct PolicyOverride {
     pub rule_id: String,
     pub targets: Vec<String>,
     pub reason: String,
+    #[serde(default)]
+    pub expires_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -192,6 +194,17 @@ impl PolicyProfileConfig {
                     ),
                 });
             }
+            if let Some(expires) = &override_entry.expires_at {
+                if chrono::NaiveDate::parse_from_str(expires, "%Y-%m-%d").is_err() {
+                    return Err(ConfigError::Validation {
+                        path: path.clone(),
+                        message: format!(
+                            "override '{}' expires_at must be in YYYY-MM-DD format (got '{}')",
+                            override_entry.rule_id, expires
+                        ),
+                    });
+                }
+            }
         }
 
         for role_binding in &self.governance_roles {
@@ -248,5 +261,31 @@ overrides:
         let err = PolicyProfileConfig::load_or_default(&path)
             .expect_err("invalid override should fail");
         assert!(err.to_string().contains("must define at least one target"));
+    }
+
+    #[test]
+    fn load_or_default_rejects_invalid_expires_at() {
+        let temp = tempdir().expect("tempdir should be created");
+        let path = temp.path().join("policy.profile.yaml");
+        std::fs::write(
+            &path,
+            r#"version: 1
+required_files:
+  - project.arch.yaml
+naming:
+  module: lowercase-identifier
+  artifact: lowercase-identifier
+overrides:
+  - rule_id: artifact-path-aligns-role
+    targets: ["foo"]
+    reason: "bar"
+    expires_at: "12-31-2025"
+"#,
+        )
+        .expect("policy should be written");
+
+        let err = PolicyProfileConfig::load_or_default(&path)
+            .expect_err("invalid expires_at should fail");
+        assert!(err.to_string().contains("expires_at must be in YYYY-MM-DD format"));
     }
 }


### PR DESCRIPTION
This pull request introduces a lifecycle for policy overrides in Archflow by adding support for an optional expiration date (`expires_at`) on overrides. Expired overrides are automatically ignored, ensuring that temporary exceptions do not become permanent technical debt. The changes include schema updates, validation, core logic for expiration handling, CLI output improvements, and new documentation.

**Policy Override Expiration Support**

*Schema and Validation:*
- Added an optional `expires_at` field (ISO 8601 date string) to policy override definitions in both the schema (`policy-profile.schema.yaml`) and Rust config structs, with validation to ensure the correct format (`YYYY-MM-DD`). Invalid formats are now rejected at load time. [[1]](diffhunk://#diff-66953d3c2c09fab438b798df2fa905753fe9dbbb102b0f2263441cb7e51b0b98R68-R71) [[2]](diffhunk://#diff-66953d3c2c09fab438b798df2fa905753fe9dbbb102b0f2263441cb7e51b0b98R106) [[3]](diffhunk://#diff-78f5839dca58231c7674fa07085530bc16d76ff996de0ec9fb159450b59c7c7bR51-R52) [[4]](diffhunk://#diff-78f5839dca58231c7674fa07085530bc16d76ff996de0ec9fb159450b59c7c7bR197-R207) [[5]](diffhunk://#diff-78f5839dca58231c7674fa07085530bc16d76ff996de0ec9fb159450b59c7c7bR265-R290)

*Core Logic and Behavior:*
- The resolution engine now checks if an override is expired (current date > `expires_at`) and structurally ignores expired overrides during policy evaluation. Expired status is tracked in the override data structure. [[1]](diffhunk://#diff-46d88afeb3abcd8d8803083a8fee57858a7f568b7e10eb82b0fde1050c961e50R135-R136) [[2]](diffhunk://#diff-46d88afeb3abcd8d8803083a8fee57858a7f568b7e10eb82b0fde1050c961e50R356-R371) [[3]](diffhunk://#diff-46d88afeb3abcd8d8803083a8fee57858a7f568b7e10eb82b0fde1050c961e50L210-R213) [[4]](diffhunk://#diff-46d88afeb3abcd8d8803083a8fee57858a7f568b7e10eb82b0fde1050c961e50R249)

*User Experience and Output:*
- The `archflow policy-resolve` CLI now tags expired overrides with `[EXPIRED]` and displays their expiration date, making it clear which overrides are no longer active.

*Testing:*
- Added tests to ensure expired overrides are ignored and active overrides are applied as expected. Also added a test for validation of the `expires_at` format. [[1]](diffhunk://#diff-46d88afeb3abcd8d8803083a8fee57858a7f568b7e10eb82b0fde1050c961e50R851-R889) [[2]](diffhunk://#diff-78f5839dca58231c7674fa07085530bc16d76ff996de0ec9fb159450b59c7c7bR265-R290) [[3]](diffhunk://#diff-35fc4ba11fabdbfeab576586b9e3caeecaacb75a294cb9d3ffe742e1c71fc723R546)

*Documentation:*
- Added a new `docs/governance-exceptions.md` guide explaining the policy exception lifecycle, how to use `expires_at`, and recommended governance workflows.

**Dependency**
- Added the `chrono` crate for robust date handling.