### PR TITLE
feat: add --evidence-export flag to audit command for JSON report serialization and documentation

### DIFF
--- a/docs/audit-evidence-retention.md
+++ b/docs/audit-evidence-retention.md
@@ -1,0 +1,78 @@
+# Audit Evidence Retention and Extraction
+
+## Overview
+
+In highly regulated environments (e.g., SOC2, ISO27001), it is not enough to simply block a pull request when an architectural rule is violated. Organizations must prove to auditors that architectural governance was consistently applied and resolved over time.
+
+To facilitate this, Archflow provides an evidence extraction workflow. By emitting structural, timestamped JSON representations of the audit report, CI/CD pipelines can reliably archive the state of governance on every merge to a trunk branch.
+
+## Generating Evidence
+
+The `archflow audit` command supports a dedicated extraction flag: `--evidence-export`. 
+
+When this flag is provided, Archflow processes the audit normally (including standard output for developers) and additionally serializes the entire `AuditReport` data structure to the requested file path.
+
+```bash
+archflow audit --evidence-export .archflow/audit-evidence.json
+```
+
+### JSON Structure
+
+The resulting JSON artifact guarantees the inclusion of a timestamp alongside all violations:
+
+```json
+{
+  "repository": ".",
+  "findings": [
+    {
+      "rule_id": "module-name-policy",
+      "severity": "Error",
+      "target": "module:legacy_Account",
+      "message": "module 'legacy_Account' does not satisfy naming rule 'KebabCase'",
+      "remediation": "Rename the module to satisfy policy naming rules or add a targeted override in policy.profile.yaml."
+    }
+  ],
+  "errors": 1,
+  "warnings": 0,
+  "timestamp": "2026-04-11T09:00:00+00:00"
+}
+```
+
+## Continuous Integration Workflow (GitHub Actions)
+
+To ensure this evidence is preserved without manual intervention, integrate the `evidence-export` mechanism directly into your CI pipeline rules. 
+
+We recommend generating this evidence on every push to the `main` or `master` branch and uploading it as a CI artifact.
+
+### Example: `.github/workflows/archflow-audit.yml`
+
+```yaml
+name: Archflow Governance Audit
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  audit-and-retain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install Archflow
+        run: cargo install --path . # or download release binary
+        
+      - name: Run Audit and Export Evidence
+        run: |
+          mkdir -p .archflow-evidence
+          archflow audit --evidence-export .archflow-evidence/audit-report.json
+          
+      - name: Upload Evidence Artifact
+        if: always() # Ensure evidence is uploaded even if the audit fails
+        uses: actions/upload-artifact@v4
+        with:
+          name: archflow-audit-evidence
+          path: .archflow-evidence/audit-report.json
+          retention-days: 90
+```
+
+By guaranteeing an uploaded artifact exists for every merge, your organization automatically constructs an immutable ledger of compliance that can be provided directly to external auditors.

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -123,8 +123,8 @@ pub fn handle(command: Commands) {
             };
             render_usecase_result(output.success, "validate project");
         }
-        Commands::Audit { strict } => {
-            crate::commands::audit::execute(strict);
+        Commands::Audit { strict, evidence_export } => {
+            crate::commands::audit::execute(strict, evidence_export);
         }
         Commands::Fix { dry_run, apply } => {
             crate::commands::fix::execute(dry_run, apply);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -83,6 +83,9 @@ pub enum Commands {
         /// Treat warnings as failures (exit code 1)
         #[arg(long)]
         strict: bool,
+        /// Export audit evidence to a structured JSON file for retention
+        #[arg(long)]
+        evidence_export: Option<String>,
     },
     /// Apply conservative automatic remediations with dry-run preview
     Fix {

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -37,9 +37,10 @@ pub struct AuditReport {
     pub findings: Vec<AuditFinding>,
     pub errors: usize,
     pub warnings: usize,
+    pub timestamp: String,
 }
 
-pub fn execute(strict: bool) {
+pub fn execute(strict: bool, evidence_export: Option<String>) {
     let report = match run_for_root(Path::new(".")) {
         Ok(report) => report,
         Err(err) => {
@@ -49,6 +50,21 @@ pub fn execute(strict: bool) {
     };
 
     render_report(&report.findings);
+
+    if let Some(export_path) = evidence_export {
+        match serde_json::to_string_pretty(&report) {
+            Ok(json_content) => {
+                if let Err(e) = std::fs::write(&export_path, json_content) {
+                    eprintln!("[!] Failed to write audit evidence to {}: {}", export_path, e);
+                } else {
+                    println!("\n[i] Audit evidence successfully exported to: {}", export_path);
+                }
+            }
+            Err(e) => {
+                eprintln!("[!] Failed to serialize audit evidence: {}", e);
+            }
+        }
+    }
 
     if report.errors > 0 || (strict && report.warnings > 0) {
         std::process::exit(1);
@@ -155,6 +171,7 @@ fn build_report(root: &Path, findings: Vec<AuditFinding>) -> AuditReport {
         findings,
         errors,
         warnings,
+        timestamp: chrono::Utc::now().to_rfc3339(),
     }
 }
 


### PR DESCRIPTION
This pull request introduces an "audit evidence extraction" feature to support compliance requirements in regulated environments. It enables exporting a structured, timestamped JSON report of audit results, suitable for archival and external audits. The changes include CLI enhancements, core logic updates, and new documentation for integrating this evidence workflow into CI pipelines.

**Feature: Audit Evidence Extraction and Retention**

*CLI and Command Enhancements:*
- Added a new `--evidence-export` flag to the `archflow audit` command, allowing users to specify a file path for exporting the audit report as JSON. (`src/cli/mod.rs` [[1]](diffhunk://#diff-82453e80e064c58b8fe1569389172f4a10adc0e685de6c3a787e07bcd9d98cffR86-R88) `src/cli/commands/mod.rs` [[2]](diffhunk://#diff-38da8705fdf2662e3e19585f900ecaa4856c7edd07d6686cc3a7a8f829fd1653L126-R127)
- Updated the `execute` function for audits to accept and handle the new evidence export option, serializing the full `AuditReport` to the given path if requested. (`src/commands/audit.rs` [[1]](diffhunk://#diff-35fc4ba11fabdbfeab576586b9e3caeecaacb75a294cb9d3ffe742e1c71fc723R40-R43) [[2]](diffhunk://#diff-35fc4ba11fabdbfeab576586b9e3caeecaacb75a294cb9d3ffe742e1c71fc723R54-R68)

*Audit Report Structure:*
- Extended the `AuditReport` struct to include a `timestamp` field, ensuring every exported report is time-stamped for auditability. (`src/commands/audit.rs` [[1]](diffhunk://#diff-35fc4ba11fabdbfeab576586b9e3caeecaacb75a294cb9d3ffe742e1c71fc723R40-R43) [[2]](diffhunk://#diff-35fc4ba11fabdbfeab576586b9e3caeecaacb75a294cb9d3ffe742e1c71fc723R174)

*Documentation and CI Integration:*
- Added `docs/audit-evidence-retention.md` detailing the evidence extraction workflow, JSON structure, and a sample GitHub Actions workflow for automating evidence retention in CI.