### PR TITLE
chore: upgrade GitHub Actions checkout to v6 and fix artifact upload

### DIFF
--- a/.github/workflows/archflow-audit-pr-gate.yml
+++ b/.github/workflows/archflow-audit-pr-gate.yml
@@ -41,7 +41,7 @@ jobs:
         run: echo "value=$(echo '${{ matrix.example_dir }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
 
       - name: Upload audit log artifact
-        uses: actions/checkout@v7
+        uses: actions/upload-artifact@v7
         with:
           name: archflow-audit-log-${{ steps.artifact_suffix.outputs.value }}
           path: ${{ matrix.example_dir }}/archflow-audit.log

--- a/.github/workflows/archflow-audit-pr-gate.yml
+++ b/.github/workflows/archflow-audit-pr-gate.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -41,7 +41,7 @@ jobs:
         run: echo "value=$(echo '${{ matrix.example_dir }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
 
       - name: Upload audit log artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/checkout@v7
         with:
           name: archflow-audit-log-${{ steps.artifact_suffix.outputs.value }}
           path: ${{ matrix.example_dir }}/archflow-audit.log

--- a/.github/workflows/archflow-guard-sidecar.yml
+++ b/.github/workflows/archflow-guard-sidecar.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -41,7 +41,7 @@ jobs:
         run: echo "value=$(echo '${{ matrix.example_dir }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
 
       - name: Upload guard log artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/checkout@v7
         with:
           name: archflow-guard-log-${{ steps.artifact_suffix.outputs.value }}
           path: ${{ matrix.example_dir }}/archflow-guard.log

--- a/.github/workflows/archflow-guard-sidecar.yml
+++ b/.github/workflows/archflow-guard-sidecar.yml
@@ -41,7 +41,7 @@ jobs:
         run: echo "value=$(echo '${{ matrix.example_dir }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
 
       - name: Upload guard log artifact
-        uses: actions/checkout@v7
+        uses: actions/upload-artifact@v7
         with:
           name: archflow-guard-log-${{ steps.artifact_suffix.outputs.value }}
           path: ${{ matrix.example_dir }}/archflow-guard.log

--- a/.github/workflows/archflow-release-cli.yml
+++ b/.github/workflows/archflow-release-cli.yml
@@ -139,7 +139,7 @@ jobs:
           (cd "$DIST_DIR" && sha256sum "$ARCHIVE_NAME" > "$ARCHIVE_NAME.sha256")
 
       - name: Upload release artifact bundle
-        uses: actions/checkout@v7
+        uses: actions/upload-artifact@v7
         with:
           name: archflow-release-${{ matrix.target }}
           path: dist/*
@@ -199,7 +199,7 @@ jobs:
           (cd "$DIST_DIR" && sha256sum "$ARCHIVE_NAME" > "$ARCHIVE_NAME.sha256")
 
       - name: Upload release artifact bundle
-        uses: actions/checkout@v7
+        uses: actions/upload-artifact@v7
         with:
           name: archflow-release-aarch64-apple-darwin
           path: dist/*

--- a/.github/workflows/archflow-release-cli.yml
+++ b/.github/workflows/archflow-release-cli.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Resolve release tag
         id: release_tag
@@ -139,7 +139,7 @@ jobs:
           (cd "$DIST_DIR" && sha256sum "$ARCHIVE_NAME" > "$ARCHIVE_NAME.sha256")
 
       - name: Upload release artifact bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/checkout@v7
         with:
           name: archflow-release-${{ matrix.target }}
           path: dist/*
@@ -151,7 +151,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Resolve release tag
         id: release_tag
@@ -199,7 +199,7 @@ jobs:
           (cd "$DIST_DIR" && sha256sum "$ARCHIVE_NAME" > "$ARCHIVE_NAME.sha256")
 
       - name: Upload release artifact bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/checkout@v7
         with:
           name: archflow-release-aarch64-apple-darwin
           path: dist/*
@@ -214,7 +214,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Resolve release tag
         id: release_tag

--- a/.github/workflows/archflow-verify-example.yml
+++ b/.github/workflows/archflow-verify-example.yml
@@ -39,7 +39,7 @@ jobs:
         run: echo "value=$(echo '${{ matrix.example_dir }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
 
       - name: Upload verify log artifact
-        uses: actions/checkout@v7
+        uses: actions/upload-artifact@v7
         with:
           name: archflow-verify-log-${{ steps.artifact_suffix.outputs.value }}
           path: ${{ matrix.example_dir }}/archflow-verify.log

--- a/.github/workflows/archflow-verify-example.yml
+++ b/.github/workflows/archflow-verify-example.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -39,7 +39,7 @@ jobs:
         run: echo "value=$(echo '${{ matrix.example_dir }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
 
       - name: Upload verify log artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/checkout@v7
         with:
           name: archflow-verify-log-${{ steps.artifact_suffix.outputs.value }}
           path: ${{ matrix.example_dir }}/archflow-verify.log

--- a/.github/workflows/architecture-pr-checklist.yml
+++ b/.github/workflows/architecture-pr-checklist.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Warn on missing architecture checklist for architecture-sensitive PRs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request

--- a/.github/workflows/architecture-pr-checklist.yml
+++ b/.github/workflows/architecture-pr-checklist.yml
@@ -10,7 +10,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 jobs:

--- a/.github/workflows/auto-publish-release.yml
+++ b/.github/workflows/auto-publish-release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Resolve Cargo version tag
         id: cargo_tag

--- a/.github/workflows/onboarding-init-plan-e2e.yml
+++ b/.github/workflows/onboarding-init-plan-e2e.yml
@@ -40,7 +40,7 @@ jobs:
             --project-name "${{ matrix.project_name }}"
 
       - name: Upload onboarding logs
-        uses: actions/checkout@v7
+        uses: actions/upload-artifact@v7
         with:
           name: onboarding-e2e-${{ matrix.preset }}
           path: target/onboarding-e2e/${{ matrix.preset }}/*.log

--- a/.github/workflows/onboarding-init-plan-e2e.yml
+++ b/.github/workflows/onboarding-init-plan-e2e.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -40,7 +40,7 @@ jobs:
             --project-name "${{ matrix.project_name }}"
 
       - name: Upload onboarding logs
-        uses: actions/upload-artifact@v4
+        uses: actions/checkout@v7
         with:
           name: onboarding-e2e-${{ matrix.preset }}
           path: target/onboarding-e2e/${{ matrix.preset }}/*.log

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const title = context.payload.pull_request.title.trim()

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,7 +14,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - id: drafter
         uses: release-drafter/release-drafter@v7

--- a/.github/workflows/verify-tag-version.yml
+++ b/.github/workflows/verify-tag-version.yml
@@ -11,7 +11,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Verify tag matches Cargo.toml version
         env:

--- a/docs/audit-evidence-retention.md
+++ b/docs/audit-evidence-retention.md
@@ -68,7 +68,7 @@ jobs:
           
       - name: Upload Evidence Artifact
         if: always() # Ensure evidence is uploaded even if the audit fails
-        uses: actions/checkout@v7
+        uses: actions/upload-artifact@v7
         with:
           name: archflow-audit-evidence
           path: .archflow-evidence/audit-report.json

--- a/docs/audit-evidence-retention.md
+++ b/docs/audit-evidence-retention.md
@@ -56,7 +56,7 @@ jobs:
   audit-and-retain:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Install Archflow
         run: cargo install --path . # or download release binary
@@ -68,7 +68,7 @@ jobs:
           
       - name: Upload Evidence Artifact
         if: always() # Ensure evidence is uploaded even if the audit fails
-        uses: actions/upload-artifact@v4
+        uses: actions/checkout@v7
         with:
           name: archflow-audit-evidence
           path: .archflow-evidence/audit-report.json

--- a/examples/preset-repository-patterns/workflows/plan-scaffold-prompt-preview.yml
+++ b/examples/preset-repository-patterns/workflows/plan-scaffold-prompt-preview.yml
@@ -49,7 +49,7 @@ jobs:
           archflow prompt "${{ github.event.inputs.artifact }}" --mode "${{ github.event.inputs.mode }}" > prompt-preview.md
 
       - name: Upload prompt preview
-        uses: actions/checkout@v7
+        uses: actions/upload-artifact@v7
         with:
           name: archflow-prompt-preview-${{ github.event.inputs.artifact }}
           path: archflow/prompt-preview.md

--- a/examples/preset-repository-patterns/workflows/plan-scaffold-prompt-preview.yml
+++ b/examples/preset-repository-patterns/workflows/plan-scaffold-prompt-preview.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -49,7 +49,7 @@ jobs:
           archflow prompt "${{ github.event.inputs.artifact }}" --mode "${{ github.event.inputs.mode }}" > prompt-preview.md
 
       - name: Upload prompt preview
-        uses: actions/upload-artifact@v4
+        uses: actions/checkout@v7
         with:
           name: archflow-prompt-preview-${{ github.event.inputs.artifact }}
           path: archflow/prompt-preview.md

--- a/examples/preset-repository-patterns/workflows/verify-preset-project.yml
+++ b/examples/preset-repository-patterns/workflows/verify-preset-project.yml
@@ -36,7 +36,7 @@ jobs:
         run: archflow verify 2>&1 | tee archflow-verify.log
 
       - name: Upload verify log
-        uses: actions/checkout@v7
+        uses: actions/upload-artifact@v7
         with:
           name: archflow-verify-log
           path: archflow/archflow-verify.log

--- a/examples/preset-repository-patterns/workflows/verify-preset-project.yml
+++ b/examples/preset-repository-patterns/workflows/verify-preset-project.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -36,7 +36,7 @@ jobs:
         run: archflow verify 2>&1 | tee archflow-verify.log
 
       - name: Upload verify log
-        uses: actions/upload-artifact@v4
+        uses: actions/checkout@v7
         with:
           name: archflow-verify-log
           path: archflow/archflow-verify.log


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows and documentation to use newer versions of key GitHub Actions, primarily upgrading `actions/checkout` to v6 and `actions/upload-artifact` to v7, as well as bumping `actions/github-script` to v9 where used. These changes help keep CI pipelines up-to-date with the latest features and security patches.

**Workflow action version upgrades:**

* Upgraded `actions/checkout` from v4 to v6 in all workflows and documentation, ensuring the latest improvements and bug fixes are used. [[1]](diffhunk://#diff-737953b424538855d26fc35caf4cc7b3af8fbc28e29e7e27dae7fdb3148987ffL27-R27) [[2]](diffhunk://#diff-f5afbadbccc84055c67ab7e7020ecd5b5071a6dbe4ffcf8485c7bfd789e11ffbL27-R27) [[3]](diffhunk://#diff-8419b4b66d46b8462a6ce2216490f475f2c4c32d76607a1a6bbd4e5a9dbfbc30L44-R44) [[4]](diffhunk://#diff-8419b4b66d46b8462a6ce2216490f475f2c4c32d76607a1a6bbd4e5a9dbfbc30L154-R154) [[5]](diffhunk://#diff-8419b4b66d46b8462a6ce2216490f475f2c4c32d76607a1a6bbd4e5a9dbfbc30L217-R217) [[6]](diffhunk://#diff-7fe3d6de5f0e6c3ebe998e3f1dd64e694916dc4ffcb147082956d133fc49196eL25-R25) [[7]](diffhunk://#diff-aab828565ea3e867b62e39ab0a9a92e7ea315cd6f808167540fee3bdcdc076c4L28-R28) [[8]](diffhunk://#diff-6942706d71f70018c8f087d0a45e76d7192106920b2b3892cb86f70443ec2078L17-R17) [[9]](diffhunk://#diff-c1baa35be3e2147b3c4d539677852eba84c2b6174244885cc7f52ef816301a02L14-R14) [[10]](diffhunk://#diff-8839e722ec35a2dea55f6eb479875ab4f8442368bc2133e9b939c4db37131018L18-R18) [[11]](diffhunk://#diff-6f080b8f4ceb2cf81c7baebfaffa4e67de733bd3d8afef30e0343080eca533c2L59-R59) [[12]](diffhunk://#diff-0ac2b13e92f1629d2529c7e73ffb2e55d524c3fb8904593e83c9116eeb514b26L21-R21) [[13]](diffhunk://#diff-311d2744f8fb5de53950268437e2be76d743c9724cb26a397c1f86e563540452L17-R17)
* Upgraded `actions/upload-artifact` from v4 to v7 in all relevant workflows and documentation for improved artifact handling and performance. [[1]](diffhunk://#diff-737953b424538855d26fc35caf4cc7b3af8fbc28e29e7e27dae7fdb3148987ffL44-R44) [[2]](diffhunk://#diff-f5afbadbccc84055c67ab7e7020ecd5b5071a6dbe4ffcf8485c7bfd789e11ffbL44-R44) [[3]](diffhunk://#diff-8419b4b66d46b8462a6ce2216490f475f2c4c32d76607a1a6bbd4e5a9dbfbc30L142-R142) [[4]](diffhunk://#diff-8419b4b66d46b8462a6ce2216490f475f2c4c32d76607a1a6bbd4e5a9dbfbc30L202-R202) [[5]](diffhunk://#diff-7fe3d6de5f0e6c3ebe998e3f1dd64e694916dc4ffcb147082956d133fc49196eL42-R42) [[6]](diffhunk://#diff-aab828565ea3e867b62e39ab0a9a92e7ea315cd6f808167540fee3bdcdc076c4L43-R43) [[7]](diffhunk://#diff-6f080b8f4ceb2cf81c7baebfaffa4e67de733bd3d8afef30e0343080eca533c2L71-R71) [[8]](diffhunk://#diff-0ac2b13e92f1629d2529c7e73ffb2e55d524c3fb8904593e83c9116eeb514b26L52-R52) [[9]](diffhunk://#diff-311d2744f8fb5de53950268437e2be76d743c9724cb26a397c1f86e563540452L39-R39)

**Other action updates:**

* Updated `actions/github-script` from v7 to v9 in workflows that use it, ensuring compatibility and access to the latest features. [[1]](diffhunk://#diff-852893758c97f0ae7cb6a0a6dacf40a5e153e36d817f302dc8911590e41bb9acL13-R21) [[2]](diffhunk://#diff-74c9ec5ec6d2baa9f20a600129a99d613414006299bd62f2200586d7f89fb4b6L19-R19)

**Workflow permission adjustment:**

* Changed `pull-requests` permission from `read` to `write` in `architecture-pr-checklist.yml` to enable workflows to write comments or update PRs as needed.

## Missing checklist items:
- [x] Architecture rules still hold, or I documented the temporary deviation
- [x] New behavior follows `cli -> app -> domain/ports` flow where practical
- [x] I did not introduce a generic bucket such as `helpers`, `common`, `services`, `manager`, or `processor`