### PR TITLE
chore: upgrade peter-evans/create-pull-request action to v8

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Create pull request for version sync
         if: steps.version_diff.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: sync version to v${{ steps.drafter.outputs.resolved_version }} with release drafter"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of an action.

Dependency update:

* Updated the `peter-evans/create-pull-request` GitHub Action from version 7 to version 8 in the `.github/workflows/release-drafter.yml` workflow.