### PR TITLE
chore: add manual version and tag inputs to release-drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      version:
+        description: '(Optional) Specify the next version (e.g., 1.2.3). If omitted, it will be calculated automatically.'
+        required: false
+        type: string
+      tag:
+        description: '(Optional) Specify the next tag (e.g., v1.2.3). If omitted, it will be generated from the version.'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -20,6 +29,8 @@ jobs:
         uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml
+          version: ${{ github.event.inputs.version }}
+          tag: ${{ github.event.inputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This pull request updates the `release-drafter` GitHub Actions workflow to support manually specifying the next version and tag when triggering a release draft. This gives more flexibility when creating releases from the workflow dispatch event.

**Workflow improvements:**

* Added optional `version` and `tag` input fields to the `workflow_dispatch` trigger in `.github/workflows/release-drafter.yml`, allowing users to specify the next version and tag when manually running the workflow.
* Updated the `release-drafter` job to use the provided `version` and `tag` inputs, passing them to the Release Drafter action.