### PR TITLE
feat: Implement SSH-based trust verification and automated governance testing

### DIFF
--- a/.github/trust/allowed_signers
+++ b/.github/trust/allowed_signers
@@ -1,0 +1,1 @@
+governance@archflow.io ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGppKXUTTNL4a8nUAy7rjB/oSYBZT9FcoHj84Zw668c5

--- a/.github/workflows/preset-trust-verification.yml
+++ b/.github/workflows/preset-trust-verification.yml
@@ -1,0 +1,29 @@
+name: Preset Trust Verification
+
+on:
+  pull_request:
+    paths:
+      - 'presets/**'
+      - '.github/trust/allowed_signers'
+      - 'scripts/verify_trust.sh'
+  workflow_dispatch:
+
+jobs:
+  verify-governance-controls:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate Trust Verification Tests
+        run: |
+          chmod +x ./scripts/test_verify_trust.sh
+          ./scripts/test_verify_trust.sh
+
+      - name: Check allowed_signers format
+        run: |
+          if [ -f .github/trust/allowed_signers ]; then
+            # Ensure it can be parsed by ssh-keygen
+            ssh-keygen -l -f .github/trust/allowed_signers
+          else
+            echo "::warning::allowed_signers file is missing."
+          fi

--- a/.github/workflows/sign-release-assets.yml
+++ b/.github/workflows/sign-release-assets.yml
@@ -1,0 +1,47 @@
+name: Sign Release Assets
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  sign-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download release assets
+        uses: dsaltares/fetch-gh-release-asset@master
+        with:
+          version: 'tags/${{ github.event.release.tag_name }}'
+          file: '.*\.tar\.gz'
+          regex: true
+          target: 'release-assets/'
+
+      - name: Setup Signing Key
+        env:
+          GOVERNANCE_PRIVATE_KEY: ${{ secrets.GOVERNANCE_PRIVATE_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$GOVERNANCE_PRIVATE_KEY" > ~/.ssh/governance_key
+          chmod 600 ~/.ssh/governance_key
+
+      - name: Sign Presets
+        run: |
+          for asset in release-assets/*.tar.gz; do
+            if [ -f "$asset" ]; then
+              echo "Signing $asset..."
+              ssh-keygen -Y sign -f ~/.ssh/governance_key -n file "$asset"
+            fi
+          done
+
+      - name: Upload Signatures
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for sig in release-assets/*.tar.gz.sig; do
+            if [ -f "$sig" ]; then
+              echo "Uploading $sig..."
+              gh release upload "${{ github.event.release.tag_name }}" "$sig"
+            fi
+          done

--- a/docs/concepts/trust.md
+++ b/docs/concepts/trust.md
@@ -1,0 +1,107 @@
+# Preset Trust Verification
+
+Archflow ensures the integrity and origin authenticity of distribution presets using cryptographically signed release assets. This document defines the structural governance operations for maintaining this pipeline.
+
+The target audience for this document includes platform operators, security auditors, and release engineers who need to understand how trust is established, verified, and safely rotated over time.
+
+## Root of Trust
+
+The primary mechanism for providing origin authenticity is **Ed25519 SSH Signatures**. 
+All official releases and trusted partner preset bundles are signed out-of-band during the release process.
+
+The "Root of Trust" for verifying these signatures is directly committed to the repository at `.github/trust/allowed_signers`. 
+
+Any consumer can verify the integrity of a preset manually via:
+```bash
+ssh-keygen -Y verify -f .github/trust/allowed_signers -I governance@archflow.io -n file -s preset.tar.gz.sig < preset.tar.gz
+```
+
+Because public keys are distributed within the repository itself, they are naturally tied to the version control history, allowing any system to determine exactly which keys were considered authoritative at any given commit.
+
+## Key Lifecycle Handling
+
+Consistent operational hygiene requires a predictable key lifecycle.
+
+### 1. Generation
+
+To ensure non-repudiation, private keys are generated strictly in offline environments or highly restricted CI secure enclaves. 
+- Generated keys MUST use the Ed25519 algorithm.
+- No private key material should ever touch an unencrypted disk on an internet-connected boundary outside of a short-lived memory context during the actual signing operation.
+
+### 2. Distribution
+
+Public identities (Trust Anchors) are formatted as single-line OpenSSH formats and placed in the `.github/trust/allowed_signers` file. 
+- A given public key is bound to a specific semantic identity, usually identifying the system emitting the signature (e.g., `governance@archflow.io`).
+- Adding a new identity to this file constitutes an explicit designation of trust.
+
+### 3. Rotation
+
+To minimize the impact of long-term key exhaustion, keys undergo planned rotation:
+- **Overlap Period**: When a new key is generated, it is added to the `allowed_signers` file while the previous key remains. Both keys remain valid during a transition period (e.g., 30 days).
+- New releases are immediately signed with the *new* active key.
+- Consumers of verification tooling will continue to trust older presets signed by the previous key until that key is formally removed from the explicit trust list.
+
+### 4. Revocation
+
+If a private key is believed to be compromised, or when its overlap period securely concludes, it must be explicitly revoked.
+Revocation is performed by retaining the public key in the `allowed_signers` file but prepending the `revoked` marker to its declaration:
+```text
+revoked governance@archflow.io ssh-ed25519 AAAAC3...
+```
+Verification tooling explicitly rejects signatures matching a revoked public key, forcing an integrity failure for all artifacts signed by that identity.
+
+---
+
+## 日本語
+
+# Preset のトラスト検証
+
+Archflow は、暗号学的に署名されたリリースアセットを用いることで、配布される Preset の完全性とオリジンの真正性を保証します。本ドキュメントでは、このパイプラインを維持するための構造的ガバナンス運用について定義します。
+
+本ドキュメントは、トラストがどのように確立され、検証され、安全にローテーションされるかを理解する必要があるプラットフォーム・オペレーター、セキュリティ監査員、およびリリース・エンジニアを対象としています。
+
+## トラストの起点 (Root of Trust)
+
+オリジンの真正性を提供する主なメカニズムは **Ed25519 SSH Signatures** です。
+公式のリリースおよび信頼できるパートナーの Preset バンドルはすべて、リリースプロセスにおいてアウトオブバンドで署名されます。
+
+これらの署名を検証するための「トラストの起点（Root of Trust）」は、リポジトリの `.github/trust/allowed_signers` に直接コミットされています。
+
+利用者は以下のコマンドを通じて、手動で Preset の完全性を検証することができます：
+```bash
+ssh-keygen -Y verify -f .github/trust/allowed_signers -I governance@archflow.io -n file -s preset.tar.gz.sig < preset.tar.gz
+```
+
+公開鍵がリポジトリ自体に配布されているため、それらはバージョン管理の履歴と自然に結びつき、任意のコミットにおいてどの鍵が権威づけられていたかをどのシステムからでも正確に判定できます。
+
+## 鍵のライフサイクル処理
+
+一貫した運用衛生を保つには、予測可能な鍵のライフサイクルが必要です。
+
+### 1. 生成 (Generation)
+
+否認防止を確実にするため、秘密鍵は厳密にオフライン環境、または高度に制限された CI のセキュアエンクレーブでのみ生成されます。
+- 生成される鍵は Ed25519 アルゴリズムを使用しなければなりません（MUST）。
+- 秘密鍵のデータは、実際の署名操作時の短命なメモリコンテキストを除き、インターネットに接続された境界上の暗号化されていないディスクに決して触れさせてはなりません。
+
+### 2. 配布 (Distribution)
+
+公開 ID（トラスト・アンカー）は1行の OpenSSH 形式でフォーマットされ、`.github/trust/allowed_signers` ファイルに配置されます。
+- ある公開鍵は特定のセマンティック・アイデンティティに紐付き、通常は署名を発行するシステム（例: `governance@archflow.io`）を識別します。
+- このファイルに新しい ID を追加することは、明示的な信頼の指定を意味します。
+
+### 3. ローテーション (Rotation)
+
+長期的な鍵の利用によるリスクを最小化するため、鍵は計画的にローテーションされます：
+- **オーバーラップ期間**: 新しい鍵が生成されると、古い鍵が残されたまま `allowed_signers` ファイルに追加されます。移行期間中（例: 30日間）は、両方の鍵が有効です。
+- 新しいリリースは、ただちに *新しく* アクティブになった鍵で署名されます。
+- 検証ツールの利用者は、古い鍵が明示的なトラストリストから正式に削除されるまで、以前の鍵で署名された古い Preset を引き続き信頼します。
+
+### 4. 失効 (Revocation)
+
+秘密鍵の漏洩が疑われる場合、もしくはオーバーラップ期間が安全に終了した場合、鍵は明示的に失効させなければなりません。
+失効は、公開鍵を `allowed_signers` ファイルに保持したまま、その宣言の先頭に `revoked` マーカーを付与することで実行されます：
+```text
+revoked governance@archflow.io ssh-ed25519 AAAAC3...
+```
+検証ツールは、失効した公開鍵に一致する署名を明示的に拒否し、その ID によって署名されたすべてのアーティファクトに対して完全性エラーを強制します。

--- a/docs/decisions/0024-preset-signature-and-trust-verification.md
+++ b/docs/decisions/0024-preset-signature-and-trust-verification.md
@@ -1,0 +1,84 @@
+# 0024-preset-signature-and-trust-verification
+
+- Status: proposed
+- Date: 2026-04-13
+
+## Context
+
+As Archflow scales to support an ecosystem of independent presets, it must establish a reliable mechanism to ensure the integrity and authenticity of preset bundles consumed by end-users. Consumers need confidence that a preset actually originated from the claimed source (Archflow maintainers or a trusted partner) and has not suffered from tampering during distribution.
+
+To effectively deliver the phase objectives around ecosystem governance, we need to choose a signature mechanism and define the trust verification pipeline that includes key lifecycle handling.
+
+Questions to answer:
+- How do we digitally sign release assets (presets) without imposing heavy operational dependencies?
+- Where do we store the public anchors (keys) that confirm authenticity?
+- How is key lifecycle handling (rotation, revocation) managed transparently?
+
+## Decision
+
+We will use **Ed25519 SSH Signatures (`ssh-keygen -Y`)** to sign and verify presets.
+
+- **Storage**: Public keys will be stored within the repository at `.github/trust/allowed_signers` using the standard OpenSSH `allowed_signers` format.
+- **Verification**: The `scripts/verify_trust.sh` utility will execute `ssh-keygen -Y verify` against the preset bundle and its signature (`.sig`) using the repository's `allowed_signers` file as the root of trust.
+- **Lifecycle Handling**:
+  - Keys are generated offline in a secure enclave.
+  - Active keys are appended to `allowed_signers` under a specific principle or identity namespace (e.g., `governance@archflow.io`).
+  - Key rotation is executed by adding a new key to the file while retaining the old one for a defined overlap period.
+  - Key revocation is executed by adding the `revoked` marker to the public key entry, permanently invalidating it for future and past verifications.
+
+Contributors should assume that any official release automation will mandate a signature, and downstream consumers can optionally verify the integrity natively using their existing SSH tooling.
+
+## Consequences
+
+- **What becomes easier**: Verifying presets requires zero external tooling installations for users since `ssh-keygen` is already distributed on any platform capable of running Git.
+- **What becomes harder**: Key lifecycle operations are manual governance steps (e.g., maintainers must carefully manage the private key offline and submit PRs to rotate the public anchors).
+- **What future work is enabled**: The `allowed_signers` format scales organically. We can easily segment trust boundaries (e.g., `partner@...`, `core@...`) or distribute the file through a centralized directory.
+- **What tradeoffs were accepted**: Providing an offline-first, highly standard implementation takes precedence over features provided by more complex but automated setups like Sigstore's keyless identity federation. 
+
+## Alternatives considered
+
+- **Sigstore/Cosign**: Offers keyless OIDC-based signature and transparency logs. Rejected for the minimal phase because it complicates offline environments and hides explicit key lifecycle handling behind dynamic, short-lived ephemeral certificates, increasing operational opacity for a simple governance model.
+- **GPG (GNU Privacy Guard)**: Highly established but suffers from difficult CLI ergonomics and complex web-of-trust setups. Storing and distributing GPG public keyrings is more friction-heavy than standard `.ssh` formatted strings.
+- **Minisign**: Excellent cryptography and simplicity, but requires an additional tool installation for every user compared to the ubiquity of SSH tools.
+
+---
+
+## 日本語
+
+### Context
+
+Archflow が独立した Preset のエコシステムをサポートするようスケールするにつれ、エンドユーザーが利用する Preset バンドルの完全性と真正性を保証する信頼性の高いメカニズムを確立する必要があります。Preset の利用者は、その Preset が実際に主張するソース（Archflow メンテナや信頼できるパートナー）から提供されたものであり、配布中に改ざんされていないという確証を必要としています。
+
+エコシステム・ガバナンスにおけるフェーズ目標を効果的に達成するため、署名メカニズムを選定し、鍵のライフサイクル管理を含むトラスト検証パイプラインを定義する必要があります。
+
+回答すべき問い：
+- 重い運用依存を強いることなく、リリースアセット（Preset）にどのようにデジタル署名を行うか？
+- 真正性を確認するための公開アンカー（公開鍵）をどこに保存するか？
+- 鍵のライフサイクル処理（ローテーション、失効処理）をいかに透明に管理するか？
+
+### Decision
+
+Preset の署名および検証には **Ed25519 SSH Signatures (`ssh-keygen -Y`)** を使用します。
+
+- **保存先**: 公開鍵はリポジトリ内の `.github/trust/allowed_signers` に、標準的な OpenSSH の `allowed_signers` 形式で保存されます。
+- **検証**: `scripts/verify_trust.sh` ユーティリティは、リポジトリの `allowed_signers` ファイルを信頼の起点として使用し、Preset バンドルとその署名 (`.sig`) に対して `ssh-keygen -Y verify` を実行します。
+- **ライフサイクル処理**:
+  - 鍵はオフラインのセキュアエンクレーブで生成されます。
+  - 有効な鍵は、特定のプリンシパルまたは ID ネームスペース（例: `governance@archflow.io`）のもと、`allowed_signers` に追記されます。
+  - 鍵のローテーションは、定義されたオーバーラップ期間中は古い鍵を維持しつつ、新しい鍵をファイルに追加することで実行されます。
+  - 鍵の失効処理は、公開鍵エントリに `revoked` マーカーを追記することで実行され、過去および将来の検証において永続的に無効化されます。
+
+コントリビューターは、公式のリリース自動化において署名が必須となること、またダウンストリームでの利用者は既存の SSH ツールを用いてネイティブに完全性を検証できることを前提として進めるべきです。
+
+### Consequences
+
+- **容易になること**: Git を実行できるあらゆるプラットフォームに `ssh-keygen` がすでに配布されているため、ユーザーは外部ツールをインストールすることなくゼロ依存で Preset の検証が可能です。
+- **困難になること**: 鍵のライフサイクル運用が手動のガバナンス・ステップとなります（たとえば、メンテナは秘密鍵を慎重にオフラインで管理し、公開アンカーをローテーションする PR を提出する必要があります）。
+- **可能になる今後の取り組み**: `allowed_signers` 形式は自然にスケールします。トラストの境界（例: `partner@...`, `core@...`）を簡単に分割したり、ファイルを中央集権的なディレクトリ経由で配布することができます。
+- **受け入れたトレードオフ**: フェデレーションや Sigstore のような OIDC ベースの動的で複雑な自動セットアップが提供する機能よりも、透明で標準的なオフラインファーストの実装を優先しました。
+
+### Alternatives considered
+
+- **Sigstore/Cosign**: キーレスな OIDC ベースの署名と透明性ログを提供します。オフライン環境を複雑にし、明示的な鍵のライフサイクル処理を動的で短命な一時的証明書の背後に隠してしまい、単純なガバナンスモデルにおいては運用の不透明さを増大させるため、今回の最小フェーズでは採用を見送りました。
+- **GPG (GNU Privacy Guard)**: 非常に確立されていますが、CLI のエルゴノミクスが難解で、Web of Trust のセットアップが複雑です。GPG の公開鍵リングを保存し配布することは、標準的な `.ssh` 形式の文字列よりも摩擦が大きくなります。
+- **Minisign**: 優れた暗号化機能とシンプルさを備えていますが、SSH ツールの普及度と比較すると、すべてのユーザーに追加のツールインストールを要求することになります。

--- a/scripts/test_verify_trust.sh
+++ b/scripts/test_verify_trust.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+# test_verify_trust.sh
+# Validates the governance operations for trust verification.
+
+echo "Running Trust Verification Tests..."
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Generate an ephemeral core identity
+ssh-keygen -t ed25519 -N "" -C "governance@archflow.io" -f "$TMP_DIR/core_key" -q
+CORE_PUB=$(cat "$TMP_DIR/core_key.pub")
+
+# Generate an ephemeral partner identity
+ssh-keygen -t ed25519 -N "" -C "partner@example.com" -f "$TMP_DIR/partner_key" -q
+PARTNER_PUB=$(cat "$TMP_DIR/partner_key.pub")
+
+# Create mock allowed_signers
+ALLOWED_SIGNERS="$TMP_DIR/allowed_signers"
+echo "governance@archflow.io $CORE_PUB" > "$ALLOWED_SIGNERS"
+echo "partner@example.com $PARTNER_PUB" >> "$ALLOWED_SIGNERS"
+
+# Create a mock preset bundle
+MOCK_PRESET="$TMP_DIR/preset.tar.gz"
+echo "dummy preset contents" > "$MOCK_PRESET"
+
+# 1. Sign with valid core key
+ssh-keygen -Y sign -f "$TMP_DIR/core_key" -n file "$MOCK_PRESET" >/dev/null 2>&1
+MOCK_SIG="$MOCK_PRESET.sig"
+
+echo "TEST 1: Validating legitimate signature..."
+if ./scripts/verify_trust.sh governance@archflow.io "$MOCK_SIG" "$MOCK_PRESET" "$ALLOWED_SIGNERS" >/dev/null; then
+    echo "  [PASS] Legitimate signature verified."
+else
+    echo "  [FAIL] Legitimate signature failed verification."
+    exit 1
+fi
+
+# 2. Try validating the core signature with the partner identity
+echo "TEST 2: Validating wrong identity bounds..."
+if ./scripts/verify_trust.sh partner@example.com "$MOCK_SIG" "$MOCK_PRESET" "$ALLOWED_SIGNERS" >/dev/null 2>&1; then
+    echo "  [FAIL] Signature wrongly accepted under different identity."
+    exit 1
+else
+    echo "  [PASS] Signature rejected for wrong identity."
+fi
+
+# 3. Modify the bundle (tamper)
+echo "tampered" >> "$MOCK_PRESET"
+
+echo "TEST 3: Validating tampered asset..."
+if ./scripts/verify_trust.sh governance@archflow.io "$MOCK_SIG" "$MOCK_PRESET" "$ALLOWED_SIGNERS" >/dev/null 2>&1; then
+    echo "  [FAIL] Tampered asset was accepted."
+    exit 1
+else
+    echo "  [PASS] Tampered asset rejected."
+fi
+echo "dummy preset contents" > "$MOCK_PRESET" # restore
+
+# 4. Revocation Test
+echo "revoked governance@archflow.io $CORE_PUB" > "$ALLOWED_SIGNERS"
+
+echo "TEST 4: Validating revoked key..."
+if ./scripts/verify_trust.sh governance@archflow.io "$MOCK_SIG" "$MOCK_PRESET" "$ALLOWED_SIGNERS" >/dev/null 2>&1; then
+    echo "  [FAIL] Revoked key signature was accepted."
+    exit 1
+else
+    echo "  [PASS] Revoked key signature rejected."
+fi
+
+echo ""
+echo "All governance assurance tests passed successfully."
+exit 0

--- a/scripts/verify_trust.sh
+++ b/scripts/verify_trust.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+# verify_trust.sh
+# Verifies the origin authenticity of an Archflow asset using SSH Ed25519 signatures.
+# 
+# Usage:
+#   ./scripts/verify_trust.sh <identity> <signature-file> <target-file> [allowed-signers-file]
+#
+# Example:
+#   ./scripts/verify_trust.sh governance@archflow.io generic-layered.tar.gz.sig generic-layered.tar.gz
+
+IDENTITY=${1:-}
+SIGNATURE_FILE=${2:-}
+TARGET_FILE=${3:-}
+ALLOWED_SIGNERS_FILE=${4:-".github/trust/allowed_signers"}
+
+if [[ -z "$IDENTITY" || -z "$SIGNATURE_FILE" || -z "$TARGET_FILE" ]]; then
+    echo "Error: Missing required arguments."
+    echo "Usage: $0 <identity> <signature-file> <target-file> [allowed-signers-file]"
+    exit 1
+fi
+
+if [[ ! -f "$ALLOWED_SIGNERS_FILE" ]]; then
+    echo "Error: Allowed signers file not found at $ALLOWED_SIGNERS_FILE"
+    exit 1
+fi
+
+if [[ ! -f "$SIGNATURE_FILE" ]]; then
+    echo "Error: Signature file not found at $SIGNATURE_FILE"
+    exit 1
+fi
+
+if [[ ! -f "$TARGET_FILE" ]]; then
+    echo "Error: Target file not found at $TARGET_FILE"
+    exit 1
+fi
+
+echo "Verifying trust for $TARGET_FILE using identity $IDENTITY..."
+
+# Perform verification
+if ssh-keygen -Y verify -f "$ALLOWED_SIGNERS_FILE" -I "$IDENTITY" -n file -s "$SIGNATURE_FILE" < "$TARGET_FILE"; then
+    echo "[SUCCESS] Verification passed: Origin authenticity confirmed."
+    exit 0
+else
+    echo "[ERROR] Verification failed: Invalid signature, identity mismatch, or revoked key."
+    exit 1
+fi


### PR DESCRIPTION
This pull request introduces a comprehensive trust verification pipeline for preset release assets, establishing cryptographic signature governance and automated verification for the Archflow project. It adds documentation, scripts, and CI workflows to ensure preset integrity and authenticity, defines key lifecycle operations (generation, rotation, revocation), and provides both English and Japanese documentation for transparency and auditability.

**Trust Verification Pipeline Implementation**

* Added `.github/workflows/sign-release-assets.yml` to automate signing of release assets on GitHub releases using Ed25519 SSH signatures, with signature upload to the release.
* Added `.github/workflows/preset-trust-verification.yml` to run trust verification and format checks on PRs affecting presets or trust configuration, invoking new test scripts.
* Added `scripts/verify_trust.sh`, a portable shell script to verify asset authenticity using SSH signatures and a repository-committed trust anchor.
* Added `scripts/test_verify_trust.sh`, a script to test the trust verification pipeline, including positive, negative, tamper, and revocation scenarios.
* Added `.github/trust/allowed_signers` to serve as the root of trust, storing allowed public keys for signature verification.

**Documentation and Governance**

* Added `docs/concepts/trust.md` detailing the trust verification pipeline, key lifecycle (generation, distribution, rotation, revocation), and operational guidance in both English and Japanese.
* Added `docs/decisions/0024-preset-signature-and-trust-verification.md` as an architecture decision record, documenting the rationale for using SSH signatures, alternatives considered, and governance implications, in both English and Japanese.