### PR TITLE
feat: Implement strict governance validation for allowed_signers

### DIFF
--- a/.github/ISSUE_TEMPLATE/partner_preset_submission.yml
+++ b/.github/ISSUE_TEMPLATE/partner_preset_submission.yml
@@ -1,0 +1,51 @@
+name: Partner preset submission / パートナーPreset提出
+description: Submit a new partner preset to the trusted ecosystem / 信頼されるエコシステムへのパートナーPreset送信
+labels: [trust, governance]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to submit your organization's preset public key (Ed25519) to Archflow's `allowed_signers` file to become a verified partner.
+        Presetの公開鍵（Ed25519）をArchflowの `allowed_signers` に登録し、検証済みパートナーとなるためにこのフォームを使用します。
+  - type: input
+    id: organization_name
+    attributes:
+      label: Organization or Entity Name / 組織名・エンティティ名
+      description: The name of the organization or partner maintaining the preset.
+      placeholder: Example Corp
+    validations:
+      required: true
+  - type: input
+    id: target_identity
+    attributes:
+      label: Target Identity / 対象アイデンティティ
+      description: The email or unique string associated with your preset signatures. (Must match what you sign with) / Preset署名に関連付けるメールアドレス等の識別子。
+      placeholder: preset@example.com
+    validations:
+      required: true
+  - type: input
+    id: public_key
+    attributes:
+      label: Ed25519 Public Key / Ed25519公開鍵
+      description: Your offline-generated ssh-ed25519 public key. / オフラインで生成された ssh-ed25519 公開鍵。
+      placeholder: ssh-ed25519 AAAAC3NzaC...
+    validations:
+      required: true
+  - type: input
+    id: preset_repository
+    attributes:
+      label: Preset Repository / Presetリポジトリ
+      description: Link to the repository where your preset is maintained. / Presetが管理されているリポジトリへのリンク。
+      placeholder: https://github.com/example/archflow-preset
+    validations:
+      required: true
+  - type: textarea
+    id: verification_contact
+    attributes:
+      label: Out-of-band Verification Contact / アウトオブバンド検証用連絡先
+      description: How can Archflow governance reviewers securely contact you to verify this key out-of-band? / Archflowガバナンス審査員がこの鍵をアウトオブバンドで安全に確認するための連絡方法。
+      placeholder: |
+        Security lead email: security@example.com
+        Identity verification context: ...
+    validations:
+      required: true

--- a/.github/workflows/preset-trust-verification.yml
+++ b/.github/workflows/preset-trust-verification.yml
@@ -6,6 +6,8 @@ on:
       - 'presets/**'
       - '.github/trust/allowed_signers'
       - 'scripts/verify_trust.sh'
+      - 'scripts/validate_allowed_signers.sh'
+      - 'scripts/test_*.sh'
   workflow_dispatch:
 
 jobs:
@@ -14,16 +16,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Validate Trust Verification Tests
+      - name: Run Trust Governance Tests
         run: |
           chmod +x ./scripts/test_verify_trust.sh
+          chmod +x ./scripts/test_validate_allowed_signers.sh
           ./scripts/test_verify_trust.sh
+          ./scripts/test_validate_allowed_signers.sh
 
-      - name: Check allowed_signers format
+      - name: Validate allowed_signers format constraints
         run: |
           if [ -f .github/trust/allowed_signers ]; then
-            # Ensure it can be parsed by ssh-keygen
-            ssh-keygen -l -f .github/trust/allowed_signers
+            chmod +x ./scripts/validate_allowed_signers.sh
+            ./scripts/validate_allowed_signers.sh .github/trust/allowed_signers
           else
             echo "::warning::allowed_signers file is missing."
           fi

--- a/docs/partner-preset-review.md
+++ b/docs/partner-preset-review.md
@@ -1,0 +1,38 @@
+# Partner Preset Review Operations
+
+This document defines the process for Archflow governance reviewers to validate and merge partner preset submissions.
+
+## Objective
+
+To maintain the integrity of Archflow's trusted ecosystem, all partner public keys added to `.github/trust/allowed_signers` must be carefully vetted. This procedure ensures origin authenticity while mitigating risks associated with supply chain attacks.
+
+## 1. Submission Review
+
+When a new partner requests inclusion via the **Partner Preset Submission** issue template:
+
+1. **Verify Formatting:** Ensure the provided key is exclusively an `ssh-ed25519` key. Our CI validation scripts (`validate_allowed_signers.sh`) will automatically enforce this natively.
+2. **Review Target Identity:** The email or identifier must logically align with the organization name and the preset they are publishing.
+
+## 2. Out-of-band Verification
+
+You MUST NOT merge a request solely because the PR checks pass.
+
+1. Take the contact method provided in the **Out-of-band Verification Contact** field.
+2. Validate the identity of the submitter by reaching out to them via a trusted, independent communication channel (e.g., organizational email signed by PGP, a shared trust channel).
+3. Confirm exactly the fingerprint of the Ed25519 key they submitted.
+
+## 3. Merge Procedure
+
+Once verified:
+1. Ensure the key is added to `.github/trust/allowed_signers` as follows:
+   `target_identity ssh-ed25519 PUBLIC_KEY_STRING`
+2. Label the corresponding PR with `trust-anchor-update`.
+3. An assigned `governance-admin` (or equivalent RBAC role) MUST approve the PR.
+4. Merge the pull request.
+
+## 4. Revocation
+
+If a partner's private key is compromised, or they are no longer maintaining their preset:
+1. Do not delete the key entirely. Instead, prepend the string `revoked ` to the key's entry in `.github/trust/allowed_signers`.
+   Example: `revoked target_identity ssh-ed25519 PUBLIC_KEY_STRING`
+2. This ensures that any CI validations attempting to verify older signed bundles will explicitly reject it as revoked, maintaining the immutable history of trust rejection.

--- a/scripts/test_validate_allowed_signers.sh
+++ b/scripts/test_validate_allowed_signers.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+# test_validate_allowed_signers.sh
+# Tests the strict governance formatting validation for allowed_signers.
+
+echo "Running allowed_signers validation tests..."
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+VALIDATOR="./scripts/validate_allowed_signers.sh"
+
+# Generate mock keys
+ssh-keygen -t ed25519 -N "" -f "$TMP_DIR/valid_key" -q
+VALID_PUB=$(cat "$TMP_DIR/valid_key.pub")
+
+ssh-keygen -t rsa -b 2048 -N "" -f "$TMP_DIR/rsa_key" -q
+RSA_PUB=$(cat "$TMP_DIR/rsa_key.pub")
+
+# Test 1: Valid file
+echo "TEST 1: Valid file"
+cat <<EOF > "$TMP_DIR/test1_signers"
+governance@arcflect.com $VALID_PUB
+EOF
+
+if $VALIDATOR "$TMP_DIR/test1_signers" > /dev/null; then
+    echo "  [PASS] Valid file accepted."
+else
+    echo "  [FAIL] Valid file rejected."
+    exit 1
+fi
+
+# Test 2: Invalid key type
+echo "TEST 2: Invalid key type (RSA)"
+cat <<EOF > "$TMP_DIR/test2_signers"
+bad@example.com $RSA_PUB
+EOF
+
+if ! $VALIDATOR "$TMP_DIR/test2_signers" > /dev/null 2>&1; then
+    echo "  [PASS] Invalid key type (RSA) rejected."
+else
+    echo "  [FAIL] Invalid key type (RSA) accepted."
+    exit 1
+fi
+
+# Test 3: Duplicate identity
+echo "TEST 3: Duplicate identity"
+cat <<EOF > "$TMP_DIR/test3_signers"
+governance@arcflect.com $VALID_PUB
+governance@arcflect.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIdummy...
+EOF
+
+if ! $VALIDATOR "$TMP_DIR/test3_signers" > /dev/null 2>&1; then
+    echo "  [PASS] Duplicate identity rejected."
+else
+    echo "  [FAIL] Duplicate identity accepted."
+    exit 1
+fi
+
+# Test 4: Malformed line
+echo "TEST 4: Malformed line"
+cat <<EOF > "$TMP_DIR/test4_signers"
+only_identity_no_key
+EOF
+
+if ! $VALIDATOR "$TMP_DIR/test4_signers" > /dev/null 2>&1; then
+    echo "  [PASS] Malformed line rejected."
+else
+    echo "  [FAIL] Malformed line accepted."
+    exit 1
+fi
+
+echo ""
+echo "All validation script tests passed successfully."
+exit 0

--- a/scripts/validate_allowed_signers.sh
+++ b/scripts/validate_allowed_signers.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+# validate_allowed_signers.sh
+# Validates the strict governance formatting of the allowed_signers file.
+#
+# Usage:
+#   ./scripts/validate_allowed_signers.sh [file_path]
+
+FILE_PATH=${1:-".github/trust/allowed_signers"}
+
+if [[ ! -f "$FILE_PATH" ]]; then
+    echo "Error: allowed_signers file not found at $FILE_PATH"
+    exit 1
+fi
+
+echo "Validating allowed_signers at $FILE_PATH..."
+
+declare -A IDENTITIES
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+    # Skip empty lines and comments
+    if [[ -z "${line// }" || "$line" =~ ^# ]]; then
+        continue
+    fi
+
+    # Check for revoked marker
+    if [[ "$line" == "revoked "* ]]; then
+        line="${line#revoked }" # Remove the revoked prefix for parsing
+    fi
+
+    # Parse components
+    # format: <identity> <keytype> <key> [comment]
+    read -r identity keytype keypart rest <<< "$line"
+
+    if [[ -z "$identity" || -z "$keytype" || -z "$keypart" ]]; then
+        echo "[ERROR] Malformed line: $line"
+        exit 1
+    fi
+
+    if [[ "$keytype" != "ssh-ed25519" ]]; then
+        echo "[ERROR] Invalid key type '$keytype' for identity '$identity'. Only ssh-ed25519 is permitted."
+        exit 1
+    fi
+    
+    if [[ -n "${IDENTITIES[$identity]:-}" ]]; then
+        echo "[ERROR] Duplicate identity found: $identity"
+        exit 1
+    fi
+
+    IDENTITIES[$identity]=1
+
+done < "$FILE_PATH"
+
+# Finally, ensure ssh-keygen can parse the file without errors
+if ! ssh-keygen -l -f "$FILE_PATH" > /dev/null 2>&1; then
+    echo "[ERROR] ssh-keygen failed to parse $FILE_PATH"
+    exit 1
+fi
+
+echo "[SUCCESS] allowed_signers passed strict validation."
+exit 0


### PR DESCRIPTION
This pull request introduces a comprehensive governance workflow for partner preset submissions, focusing on improving trust and validation for the `.github/trust/allowed_signers` file. It adds a new issue template for partner submissions, documents the review and revocation process, and strengthens CI validation by enforcing strict formatting and key type requirements. The main changes are grouped below.

**Governance and Process Documentation:**

* Added `.github/ISSUE_TEMPLATE/partner_preset_submission.yml` to standardize partner preset submissions, collecting organization, identity, public key, repository, and out-of-band contact information.
* Introduced `docs/partner-preset-review.md` outlining the review, out-of-band verification, merge, and revocation procedures for partner presets, ensuring robust governance and supply chain security.

**CI/CD and Validation Enhancements:**

* Updated `.github/workflows/preset-trust-verification.yml` to:
  - Run new trust governance tests and validate allowed signers with custom scripts.
  - Ensure only `ssh-ed25519` keys are accepted, and that the file passes strict formatting and uniqueness checks. [[1]](diffhunk://#diff-e41b9e8d37494fcdde013224b89690fcc4acb357099ac7fb306f0ffd042e4794R9-R10) [[2]](diffhunk://#diff-e41b9e8d37494fcdde013224b89690fcc4acb357099ac7fb306f0ffd042e4794L17-R30)
* Added `scripts/validate_allowed_signers.sh`, a script that enforces strict validation on the `allowed_signers` file: only allows `ssh-ed25519` keys, checks for malformed lines, duplicate identities, and ensures compatibility with `ssh-keygen`.
* Added `scripts/test_validate_allowed_signers.sh`, a test script that verifies the validator catches invalid key types, duplicate identities, and malformed lines, ensuring the validation logic is robust.