### PR TITLE
docs: formalize release acceptance criteria and integrate CI workflow gating

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,7 @@ Before submitting a PR, please confirm:
 
 - the change is scoped and explained
 - documentation is updated if needed
+- the change satisfies or updates the relevant [Acceptance Criteria](./docs/acceptance-criteria.md)
 - naming is consistent
 - the intent is clear for both humans and AI users
 - examples are updated when behavior changes
@@ -278,6 +279,7 @@ PR を送る前に、次を確認してください。
 
 - 変更範囲が明確か
 - 必要なドキュメント更新があるか
+- 関連する [受け入れ基準 (Acceptance Criteria)](./docs/acceptance-criteria.md) を満たしているか（または更新したか）
 - 命名が一貫しているか
 - 人間にも AI にも意図が伝わるか
 - 振る舞いが変わるなら examples も更新されているか

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,6 +6,7 @@ Related documents:
 - [docs/schema-guide.md](./docs/schema-guide.md)
 - [docs/architecture-flow.md](./docs/architecture-flow.md)
 - [docs/presets.md](./docs/presets.md)
+- [docs/acceptance-criteria.md](./docs/acceptance-criteria.md)
 - [docs/decisions/README.md](./docs/decisions/README.md)
 
 ---
@@ -252,7 +253,7 @@ Related docs:
 Tracking issues:
 - [#127](https://github.com/Arcflect/batonel/issues/127) Phase6 Task 1: Stabilize init/plan deterministic onboarding
 - [#128](https://github.com/Arcflect/batonel/issues/128) Phase6 Task 2: Standardize project.baton.yaml contract schema
-- [#129](https://github.com/Arcflect/batonel/issues/129) Phase6 Task 3: Expand docs, examples, and onboarding e2e coverage
+- [#129](https://github.com/Arcflect/batonel/issues/129) Phase6 Task 3: Expand docs, examples, and onboarding e2e coverage (see [Acceptance Criteria](./docs/acceptance-criteria.md))
 - [#130](https://github.com/Arcflect/batonel/issues/130) Phase7 Task 1: Implement audit baseline and PR gate integration
 - [#131](https://github.com/Arcflect/batonel/issues/131) Phase7 Task 2: Define safe fix boundaries and conservative automation
 - [#132](https://github.com/Arcflect/batonel/issues/132) Phase7 Task 3: Apply minimum policy profile across repositories

--- a/docs/acceptance-criteria.md
+++ b/docs/acceptance-criteria.md
@@ -1,0 +1,66 @@
+# Batonel Acceptance Criteria
+
+This document defines the product-level guarantees that **Batonel** must satisfy to be considered stable and release-ready. 
+These criteria elevate core CI workflows from implementation details to documented product promises.
+
+---
+
+## 1. Product Guarantees
+
+Batonel provides the following guarantees to users and contributors. These are automatically verified in CI for every pull request and release.
+
+### G1: Core Verification Integrity
+**Guarantee**: The `verify` command correctly identifies structural and contract consistency in standard architectural patterns.
+- **Verification Workflow**: `.github/workflows/batonel-verify-example.yml`
+- **Scope**: Covers `minimal`, `generic-layered`, and `rust-clean-hexagonal` examples.
+- **Failure Condition**: Any `batonel verify` command returning a non-zero exit code on standard examples.
+
+### G2: Onboarding Experience & Determinism
+**Guarantee**: New projects can be initialized from presets, and the resulting `plan` output is deterministic.
+- **Verification Workflow**: `.github/workflows/onboarding-init-plan-e2e.yml`
+- **Scope**: 
+    - `init --dry-run` must not write any files.
+    - `init` must generate all required root configuration files.
+    - `plan` must produce identical output when run multiple times on the same input.
+- **Failure Condition**: Missing files after `init`, non-deterministic `plan` output, or unexpected side effects during dry-run.
+
+### G3: Ecosystem Consistency (Parity)
+**Guarantee**: Examples and Presets remain byte-for-byte identical for shared configurations, and generated prompts are synchronized.
+- **Verification Workflow**: `.github/workflows/batonel-verify-parity.yml`
+- **Scope**: 
+    - Parity between `presets/` and `examples/*/batonel/`.
+    - Synchronization of expected prompts in examples.
+    - Schema version consistency (must use `schema_version: "1"`).
+- **Failure Condition**: Any drift between presets and examples, or out-of-sync prompt artifacts.
+
+---
+
+## 2. Release Gating
+
+A release is considered "Gated" by these criteria. No official release of Batonel shall be published if any of the following workflows fail:
+
+1. **Batonel Verify Example** (G1)
+2. **Onboarding Init-Plan E2E** (G2)
+3. **Batonel Verify Parity** (G3)
+
+For more details on the release process, see [docs/release-operations.md](./release-operations.md).
+
+---
+
+## 3. Identified Acceptance Gaps
+
+The following areas are currently identified as "Missing Coverage" and are planned for future acceptance criteria:
+
+- [ ] **Cross-platform Verification**: Currently, E2E flows only run on Linux. macOS and Windows verification is needed.
+- [ ] **Scaffold E2E**: The `scaffold` command is not yet fully verified in an automated onboarding flow.
+- [ ] **Prompt Quality Assertion**: While prompt *presence* is checked, prompt *content* effectiveness is not yet automatically measured.
+- [ ] **Audit/Policy Gate**: Integration of the `audit` command as a mandatory PR gate for downstream projects (Phase 7).
+
+---
+
+## 4. Definition of Done (DoD) for New Features
+
+Every new feature or architectural change must:
+1. **Satisfy existing guarantees**: Must not break G1, G2, or G3.
+2. **Update examples**: If behavior changes, the corresponding `examples/` must be updated to maintain parity.
+3. **Extend criteria**: If a new core capability is added (e.g., `audit`), a corresponding acceptance criterion and workflow should be established.

--- a/docs/contributing-areas.md
+++ b/docs/contributing-areas.md
@@ -190,6 +190,7 @@ This area turns concepts and schemas into a working tool.
 - scaffold generation
 - prompt generation
 - verification entry points
+- **acceptance criteria verification** (see [Acceptance Criteria](./acceptance-criteria.md))
 
 ### Good contribution types
 
@@ -257,6 +258,7 @@ Verification protects architectural intent after initial generation.
 
 - define verify scope
 - suggest first verification rules
+- expand **Product Guarantees** (see [Acceptance Criteria](./acceptance-criteria.md))
 - identify required consistency checks
 - propose example verification output
 - design status and file presence checks
@@ -637,6 +639,7 @@ CLI は Batonel が実用的になる場所です。
 - スキャフォルド生成
 - prompt 生成
 - verify のエントリポイント
+- **受け入れ基準（Acceptance Criteria）の検証** (詳細は [こちら](./acceptance-criteria.md))
 
 #### 良いコントリビューションの種類
 
@@ -702,6 +705,7 @@ Verify は初期生成後のアーキテクチャの意図を保護します。
 
 - verify のスコープを定義する
 - 最初の verify ルールを提案する
+- **製品保証（Product Guarantees）の拡充** (詳細は [こちら](./acceptance-criteria.md))
 - 必要な整合性チェックを特定する
 - verify 出力の例を設計する
 - ステータスとファイル存在チェックを設計する

--- a/docs/release-operations.md
+++ b/docs/release-operations.md
@@ -142,7 +142,19 @@ and optionally include `BREAKING CHANGE` in the PR body.
 Release Drafter auto-assigns the `major` label and bumps the major version accordingly.
 The generated release body describes all breaking changes from merged PR titles.
 
-## 7. Verification checklist
+## 7. Release Gating (Acceptance Criteria)
+
+Every release must pass the formal **Acceptance Criteria** defined in [docs/acceptance-criteria.md](./acceptance-criteria.md).
+
+The following CI workflows act as hard gates:
+
+- **Batonel Verify Example**: Ensures core `verify` logic works on all standard examples.
+- **Onboarding Init-Plan E2E**: Ensures `init` and `plan` (determinism) work correctly for new projects.
+- **Batonel Verify Parity**: Ensures presets and examples stay synchronized.
+
+If any of these workflows fail, the release must be blocked until the root cause is resolved.
+
+## 8. Verification checklist
 
 After a release is published, verify at least once in a fresh environment:
 


### PR DESCRIPTION
This pull request introduces formal acceptance criteria for the Batonel project and ensures that these criteria are referenced throughout documentation and contributor guidelines. The most significant change is the addition of a comprehensive `docs/acceptance-criteria.md` document, which defines product-level guarantees and release gating requirements. Related documentation and checklists have been updated to reference these criteria, improving clarity and alignment for contributors and maintainers.

**Acceptance Criteria Definition and Integration:**

* Added a new document, `docs/acceptance-criteria.md`, detailing Batonel's product guarantees, CI verification workflows, release gating rules, and definition of done for new features.
* Updated contributor checklists in both English and Japanese in `CONTRIBUTING.md` to require that changes satisfy or update the relevant acceptance criteria. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R120) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R282)
* Added references to the new acceptance criteria document in the related documents section of `ROADMAP.md`, and linked acceptance criteria to a key tracking issue. [[1]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51R9) [[2]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51L255-R256)
* Updated `docs/release-operations.md` to require passing the acceptance criteria for every release, and clarified which CI workflows act as release gates.

**Documentation Alignment:**

* Updated `docs/contributing-areas.md` (English and Japanese) to reference acceptance criteria verification and product guarantees as core aspects of verification and CLI contributions. [[1]](diffhunk://#diff-b45dbf187c80913326f21839c91f6a104847c2ba6f1742a2a8bfe90a72b005c0R193) [[2]](diffhunk://#diff-b45dbf187c80913326f21839c91f6a104847c2ba6f1742a2a8bfe90a72b005c0R261) [[3]](diffhunk://#diff-b45dbf187c80913326f21839c91f6a104847c2ba6f1742a2a8bfe90a72b005c0R642) [[4]](diffhunk://#diff-b45dbf187c80913326f21839c91f6a104847c2ba6f1742a2a8bfe90a72b005c0R708)