### PR TITLE
docs: add quality and trust model documentation and integrate into acceptance criteria, README, and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,17 +150,17 @@ The contract model is precise enough for a CI audit gate. It is also structured 
 
 ---
 
-## Governance and trust pipeline
+## Trust & Quality Model
 
-Batonel ships with a complete preset governance model:
+Batonel establishes a verifiable bridge between design and code through a layered **Quality & Trust Model**:
 
-- **Ed25519 SSH signatures** for signed preset bundles
-- **Allowed signers trust store** (`.github/trust/allowed_signers`) for verifiable key anchors
-- **Partner review workflow** with mandatory out-of-band identity verification
-- **Ecosystem compliance maturity benchmark** — a five-level model (L0–L4) for assessing governance posture
-- **CI enforcement** — compliance gate runs on every governance-sensitive PR
+- **Structural Validity**: Core consistency check between plan and execution (`batonel verify`).
+- **Example Parity**: Byte-for-byte synchronization between documentation and presets (`verify_parity.sh`).
+- **Preset Integrity**: Cryptographic origin authenticity using **Ed25519 SSH signatures**.
+- **Continuous Compliance**: Five-level maturity benchmark (L0–L4) enforced via CI gates.
 
-→ See [docs/ecosystem-compliance-maturity.md](./docs/ecosystem-compliance-maturity.md) for the benchmark levels.
+→ See **[docs/quality-model.md](./docs/quality-model.md)** for the full trust framework.
+→ See [docs/acceptance-criteria.md](./docs/acceptance-criteria.md) for release-gating definitions.
 
 ---
 
@@ -344,17 +344,17 @@ Batonel はその中間にあります。設計意図を実行可能にします
 
 ---
 
-## ガバナンスと信頼パイプライン
+## 信頼と品質のモデル (Trust & Quality)
 
-Batonel には完全な preset ガバナンスモデルが含まれています：
+Batonel は、多層的な **Quality & Trust Model** を通じて、設計とコードの間に検証可能な橋を架けます：
 
-- 署名済み preset バンドルのための **Ed25519 SSH 署名**
-- 検証可能な鍵アンカーのための **allowed signers トラストストア**
-- 帯域外アイデンティティ確認を義務付けた **パートナーレビューワークフロー**
-- ガバナンスポスチャを評価する **5 段階のエコシステム準拠成熟度ベンチマーク（L0–L4）**
-- ガバナンス関連 PR すべてに適用される **CI 強制ゲート**
+- **構造的妥当性**: 計画と実装の整合性を自動検証 (`batonel verify`)
+- **例示の整合性**: ドキュメントとプリセットの完全な同期を保証 (`verify_parity.sh`)
+- **プリセットの完全性**: **Ed25519 SSH 署名**によるオリジンの真正性保証
+- **継続的コンプライアンス**: 5 段階の成熟度ベンチマーク (L0–L4) によるガバナンス監査
 
-→ ベンチマークの各レベルは [docs/ecosystem-compliance-maturity.md](./docs/ecosystem-compliance-maturity.md) を参照してください。
+→ 詳細は **[docs/quality-model.md](./docs/quality-model.md)** を参照してください。
+→ リリース基準は [docs/acceptance-criteria.md](./docs/acceptance-criteria.md) を参照してください。
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,6 +7,7 @@ Related documents:
 - [docs/architecture-flow.md](./docs/architecture-flow.md)
 - [docs/presets.md](./docs/presets.md)
 - [docs/acceptance-criteria.md](./docs/acceptance-criteria.md)
+- [docs/quality-model.md](./docs/quality-model.md)
 - [docs/decisions/README.md](./docs/decisions/README.md)
 
 ---

--- a/docs/acceptance-criteria.md
+++ b/docs/acceptance-criteria.md
@@ -1,7 +1,7 @@
 # Batonel Acceptance Criteria
 
 This document defines the product-level guarantees that **Batonel** must satisfy to be considered stable and release-ready. 
-These criteria elevate core CI workflows from implementation details to documented product promises.
+These criteria elevate core CI workflows from implementation details to documented product promises, rooted in the [Batonel Quality & Trust Model](./quality-model.md).
 
 ---
 

--- a/docs/quality-model.md
+++ b/docs/quality-model.md
@@ -1,0 +1,70 @@
+# Batonel Quality & Trust Model
+
+Batonel is designed to bridge architectural intent and technical execution. To ensure this bridge remains reliable, we apply a layered **Quality & Trust Model**. This model transforms architectural promises into operational safeguards.
+
+---
+
+## 1. The Five Layers of Quality
+
+Batonel establishes trust through five progressive layers of verification and governance.
+
+### Layer 1: Structural Validity (Execution Alignment)
+**Goal**: Ensure the project structure matches its architectural definition.
+- **Mechanism**: `batonel verify` command.
+- **Safeguard**: Validates that all planned artifacts exist, contracts are complete, and paths follow placement rules.
+- **Operational Link**: [docs/concepts/verify.md](./concepts/verify.md) | `.github/workflows/batonel-verify-example.yml`
+
+### Layer 2: Example Parity (Documentation Integrity)
+**Goal**: Ensure that documentation (examples) and implementation (presets) never drift.
+- **Mechanism**: `scripts/verify_parity.sh`.
+- **Safeguard**: Performs byte-for-byte comparisons between presets and their corresponding examples. Ensures generated prompts are synchronized.
+- **Operational Link**: `scripts/verify_parity.sh` | `.github/workflows/batonel-verify-parity.yml`
+
+### Layer 3: Preset Integrity (Origin Authenticity)
+**Goal**: Protect users from malicious or accidental tampering with distribution assets.
+- **Mechanism**: **SSH Ed25519 Signatures**.
+- **Safeguard**: Verifies cryptographic signatures of preset bundles against a committed "Root of Trust" (`allowed_signers`).
+- **Operational Link**: [docs/concepts/trust.md](./concepts/trust.md) | `scripts/verify_trust.sh` | `.github/workflows/preset-trust-verification.yml`
+
+### Layer 4: Release Authenticity (Secure Distribution)
+**Goal**: Ensure the CLI binaries and release assets are authoritative.
+- **Mechanism**: Automated signing and checksum verification.
+- **Safeguard**: Releases are signed with dedicated keys, and SHA256 checksums are verified during installation.
+- **Operational Link**: [docs/release-operations.md](./release-operations.md) | `.github/workflows/sign-release-assets.yml`
+
+### Layer 5: Continuous Compliance (Maturity Governance)
+**Goal**: Maintain a high governance posture across the entire ecosystem.
+- **Mechanism**: **Ecosystem Compliance Maturity Benchmark**.
+- **Safeguard**: Assigns a maturity level (L0-L4) based on the presence of operational controls. Regressions block development.
+- **Operational Link**: [docs/ecosystem-compliance-maturity.md](./ecosystem-compliance-maturity.md) | `scripts/check_compliance_level.sh`
+
+---
+
+## 2. Operational Safeguards Summary
+
+| Control Area | Operational Script | CI/CD Workflow |
+|--------------|-------------------|---------------|
+| **Architecture** | `cargo run -- verify` | `batonel-verify-example.yml` |
+| **Drift Prevention** | `verify_parity.sh` | `batonel-verify-parity.yml` |
+| **Preset Trust** | `verify_trust.sh` | `preset-trust-verification.yml` |
+| **Distro Trust** | `install-batonel.sh` (checksum) | `sign-release-assets.yml` |
+| **Governance** | `check_compliance_level.sh` | (Maturity Gated) |
+
+---
+
+## 3. The Batonel Trust Promise
+
+Users and partners can trust Batonel because:
+
+1.  **Transparency**: Every rule, preset, and contract is defined in language-agnostic YAML or Markdown. There is no hidden logic.
+2.  **Reproducibility**: `init` and `plan` operations are deterministic. The same input always results in the same architectural plan.
+3.  **Auditability**: Public keys and governance roles are committed directly to the repository, providing a permanent, versioned audit trail of trust anchors.
+4.  **Conservative Defaults**: Verification and trust checks fail-closed. If a signature is missing or a path drifts, the process stops.
+
+---
+
+## 4. Definition of Done (DoD) Reference
+
+Any significant change to Batonel must be evaluated against this model. A feature is not "Done" until it has satisfied the relevant quality layer (e.g., adding a new preset requires establishing Layer 2 Parity and Layer 3 Integrity).
+
+For the specific release-gating criteria, see [Acceptance Criteria](./acceptance-criteria.md).


### PR DESCRIPTION
This pull request introduces a new, comprehensive "Quality & Trust Model" for Batonel and updates documentation to reflect this model. The changes clarify how Batonel ensures trust, quality, and compliance throughout its lifecycle, replacing the previous governance model with a more structured, layered approach. The most important changes are:

**Introduction of the Quality & Trust Model:**

* Added a new document, `docs/quality-model.md`, which defines a five-layer model for quality and trust, covering structural validity, documentation parity, preset integrity, release authenticity, and continuous compliance. This document details the mechanisms and safeguards for each layer, operational scripts, and the Batonel trust promise.

**Documentation and Terminology Updates:**

* Updated the English and Japanese sections of `README.md` to replace references to the old "governance and trust pipeline" with the new "Trust & Quality Model," summarizing the new layered approach and updating links to point to the new documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L153-R163) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L347-R357)
* Added a reference to the new `docs/quality-model.md` in `ROADMAP.md` for better discoverability.

**Alignment of Acceptance Criteria:**

* Updated `docs/acceptance-criteria.md` to explicitly tie product guarantees and CI workflow requirements to the new Quality & Trust Model, ensuring that acceptance criteria are rooted in the updated framework.

These changes collectively establish a clearer, more robust framework for quality and trust in Batonel, making expectations and verification mechanisms more transparent and actionable.