### PR TITLE
refactor: introduce runner module to standardize CLI execution, logging, and error handling

### DIFF
--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,18 +1,5 @@
 use crate::cli::{Commands, ComplianceReportFormat, GuardHook, PlanOutputFormat};
-
-fn render_usecase_result(success: bool, context: &str) {
-    if !success {
-        eprintln!("[!] {} failed", context);
-        std::process::exit(1);
-    }
-}
-
-fn write_rendered_output(renderer_output: &str) {
-    let mut output = crate::infra::ConsoleOutputAdapter;
-    for line in renderer_output.lines() {
-        crate::ports::OutputPort::write_line(&mut output, crate::ports::OutputLevel::Info, line);
-    }
-}
+use crate::cli::runner;
 
 struct ComplianceReportInput {
     repos: Vec<String>,
@@ -47,23 +34,18 @@ pub fn handle(command: Commands) {
             };
 
             if let Some(preset_id) = preset.as_deref() {
-                println!("Batonel Initialization (preset: {})", preset_id);
+                runner::print_command_header(&format!("Batonel Initialization (preset: {})", preset_id));
             } else {
-                println!("Batonel Initialization");
+                runner::print_command_header("Batonel Initialization");
             }
-            println!("=======================");
 
             if dry_run {
                 println!("  [i] Dry run mode enabled. No files will be written.");
             }
 
-            let output = match crate::app::usecase::InitProjectUseCase::execute(input) {
-                Ok(output) => output,
-                Err(err) => {
-                    eprintln!("[!] init project failed: {}", err);
-                    std::process::exit(1);
-                }
-            };
+            let output = runner::run_usecase("init project", || {
+                crate::app::usecase::InitProjectUseCase::execute(input)
+            });
 
             for result in &output.file_results {
                 if dry_run {
@@ -94,7 +76,7 @@ pub fn handle(command: Commands) {
                 println!("Initialization finished. No new configuration files were generated.");
             }
 
-            render_usecase_result(output.success, "init project");
+            runner::exit_on_failure(output.success, "init project");
         }
         Commands::Plan { format } => {
             let usecase_format = match format {
@@ -103,69 +85,52 @@ pub fn handle(command: Commands) {
                 PlanOutputFormat::Markdown => crate::app::usecase::PlanRenderFormat::Markdown,
             };
 
-            let usecase_output = match crate::app::usecase::PlanArchitectureUseCase::execute(
-                crate::app::usecase::PlanArchitectureInput {
-                    format: usecase_format,
-                },
-            ) {
-                Ok(result) => result,
-                Err(err) => {
-                    eprintln!("[!] plan architecture failed: {}", err);
-                    std::process::exit(1);
-                }
-            };
+            let usecase_output = runner::run_usecase("plan architecture", || {
+                crate::app::usecase::PlanArchitectureUseCase::execute(
+                    crate::app::usecase::PlanArchitectureInput {
+                        format: usecase_format,
+                    },
+                )
+            });
 
             let rendered = match format {
                 PlanOutputFormat::Text => {
                     crate::infra::PlanRendererAdapter::render_text(&usecase_output)
                 }
                 PlanOutputFormat::Json => {
-                    match crate::infra::PlanRendererAdapter::render_json(&usecase_output) {
-                        Ok(s) => s,
-                        Err(err) => {
-                            eprintln!("[!] failed to render json output: {}", err);
-                            std::process::exit(1);
-                        }
-                    }
+                    runner::run_usecase("render json output", || {
+                        crate::infra::PlanRendererAdapter::render_json(&usecase_output)
+                    })
                 }
                 PlanOutputFormat::Markdown => {
                     crate::infra::PlanRendererAdapter::render_markdown(&usecase_output)
                 }
             };
 
-            write_rendered_output(&rendered);
-            render_usecase_result(usecase_output.success, "plan architecture");
+            runner::write_output(&rendered);
+            runner::exit_on_failure(usecase_output.success, "plan architecture");
         }
         Commands::Scaffold => {
-            let output = match crate::app::usecase::GenerateArtifactsUseCase::execute(
-                crate::app::usecase::GenerateArtifactsInput,
-            ) {
-                Ok(output) => output,
-                Err(err) => {
-                    eprintln!("[!] generate artifacts failed: {}", err);
-                    std::process::exit(1);
-                }
-            };
+            let output = runner::run_usecase("generate artifacts", || {
+                crate::app::usecase::GenerateArtifactsUseCase::execute(
+                    crate::app::usecase::GenerateArtifactsInput,
+                )
+            });
             println!();
             println!(
                 "Scaffold result: {} generated, {} errors.",
                 output.generated_count, output.error_count
             );
-            render_usecase_result(output.success, "generate artifacts");
+            runner::exit_on_failure(output.success, "generate artifacts");
         }
         Commands::Verify => {
-            println!("Batonel Architectural Verification");
-            println!("==================================");
+            runner::print_command_header("Batonel Architectural Verification");
 
-            let output = match crate::app::usecase::ValidateProjectUseCase::execute(
-                crate::app::usecase::ValidateProjectInput,
-            ) {
-                Ok(output) => output,
-                Err(err) => {
-                    eprintln!("[!] validate project failed: {}", err);
-                    std::process::exit(1);
-                }
-            };
+            let output = runner::run_usecase("validate project", || {
+                crate::app::usecase::ValidateProjectUseCase::execute(
+                    crate::app::usecase::ValidateProjectInput,
+                )
+            });
 
             if output.structural_errors > 0 || output.structural_warnings > 0 {
                 println!(
@@ -175,7 +140,7 @@ pub fn handle(command: Commands) {
             }
 
             crate::commands::verify::render_report(&output.report);
-            render_usecase_result(output.success, "validate project");
+            runner::exit_on_failure(output.success, "validate project");
         }
 
         // ==========================================

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand, ValueEnum};
 
 pub mod commands;
+pub mod runner;
 
 #[derive(Parser)]
 #[command(author = "hirontan", version, about, long_about = None)]

--- a/src/cli/runner.rs
+++ b/src/cli/runner.rs
@@ -1,0 +1,105 @@
+//! Generic CLI execution pipeline helpers.
+//!
+//! These utilities contain no product-specific wording. They standardise the
+//! three plumbing concerns that every command arm must handle:
+//!
+//! 1. Running a usecase and exiting cleanly on error.
+//! 2. Printing a consistent command-start banner.
+//! 3. Writing rendered output through the output port.
+
+use std::fmt::Display;
+
+// ---------------------------------------------------------------------------
+// Public helpers
+// ---------------------------------------------------------------------------
+
+/// Execute `f` and return the output. On `Err`, print `"[!] {label}: {err}"` to
+/// stderr and terminate with exit code 1.
+///
+/// `label` should be a short, lowercase description of what was attempted (e.g.
+/// `"init project"`, `"plan architecture"`). It **must not** contain
+/// product-specific output phrasing — that belongs in the caller.
+pub fn run_usecase<T, E, F>(label: &str, f: F) -> T
+where
+    E: Display,
+    F: FnOnce() -> Result<T, E>,
+{
+    match f() {
+        Ok(output) => output,
+        Err(err) => {
+            eprintln!("[!] {}: {}", label, err);
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Print a two-line command banner to stdout: the title followed by a `"="`
+/// separator of the same width.
+///
+/// Example output:
+/// ```text
+/// Batonel Initialization
+/// ======================
+/// ```
+///
+/// Only call this for commands where a start banner improves readability. Do
+/// not call it for streaming or machine-readable output commands.
+pub fn print_command_header(title: &str) {
+    println!("{}", title);
+    println!("{}", "=".repeat(title.len()));
+}
+
+/// If `success` is `false`, print `"[!] {label} failed"` to stderr and
+/// terminate with exit code 1.
+///
+/// Used as the final gate for usecase-backed commands after all output has
+/// been rendered.
+pub fn exit_on_failure(success: bool, label: &str) {
+    if !success {
+        eprintln!("[!] {} failed", label);
+        std::process::exit(1);
+    }
+}
+
+/// Write each line of `output` to stdout via the `OutputPort`.
+///
+/// This is the standard way to emit pre-rendered multi-line output (e.g. from
+/// `PlanRendererAdapter`) without coupling the rendering layer to `println!`
+/// directly.
+pub fn write_output(output: &str) {
+    let mut adapter = crate::infra::ConsoleOutputAdapter;
+    for line in output.lines() {
+        crate::ports::OutputPort::write_line(
+            &mut adapter,
+            crate::ports::OutputLevel::Info,
+            line,
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::{exit_on_failure, run_usecase};
+
+    #[test]
+    fn run_usecase_returns_value_on_ok() {
+        let result: u32 = run_usecase("demo", || Ok::<u32, String>(42));
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn run_usecase_propagates_inner_value() {
+        let result: Vec<u8> = run_usecase("demo", || Ok::<Vec<u8>, String>(vec![1, 2, 3]));
+        assert_eq!(result, vec![1, 2, 3]);
+    }
+
+    // exit_on_failure with success=true is a no-op — just verify it doesn't panic.
+    #[test]
+    fn exit_on_failure_does_not_panic_on_success() {
+        exit_on_failure(true, "test context");
+    }
+}

--- a/src/commands/prompt.rs
+++ b/src/commands/prompt.rs
@@ -11,7 +11,7 @@ pub fn execute(target: &str, mode: OutputMode) {
         let placement_config = match PlacementRulesConfig::load("placement.rules.yaml") {
             Ok(config) => config,
             Err(e) => {
-                eprintln!("Error: Loading placement rules failed: {}", e);
+                eprintln!("[!] loading placement rules failed: {}", e);
                 std::process::exit(1);
             }
         };
@@ -19,7 +19,7 @@ pub fn execute(target: &str, mode: OutputMode) {
         let artifacts_config = match ArtifactsPlanConfig::load("artifacts.plan.yaml") {
             Ok(config) => config,
             Err(e) => {
-                eprintln!("Error: Loading artifacts plan failed: {}", e);
+                eprintln!("[!] loading artifacts plan failed: {}", e);
                 std::process::exit(1);
             }
         };
@@ -28,10 +28,7 @@ pub fn execute(target: &str, mode: OutputMode) {
         let artifact = match artifacts_config.artifacts.iter().find(|a| a.name == target) {
             Some(a) => a,
             None => {
-                eprintln!(
-                    "Error: Artifact '{}' not found in artifacts.plan.yaml",
-                    target
-                );
+                eprintln!("[!] artifact '{}' not found in artifacts.plan.yaml", target);
                 std::process::exit(1);
             }
         };
@@ -41,7 +38,7 @@ pub fn execute(target: &str, mode: OutputMode) {
             match crate::generator::resolver::resolve_artifact_path(artifact, &placement_config) {
                 Ok(p) => p,
                 Err(e) => {
-                    eprintln!("Error: Resolving artifact path failed: {}", e);
+                    eprintln!("[!] resolving artifact path failed: {}", e);
                     std::process::exit(1);
                 }
             };
@@ -62,11 +59,7 @@ pub fn execute(target: &str, mode: OutputMode) {
     let contract_config = match ContractConfig::load(&contract_path) {
         Ok(config) => config,
         Err(e) => {
-            eprintln!(
-                "Error: Loading contract at {} failed: {}",
-                contract_path.display(),
-                e
-            );
+            eprintln!("[!] loading contract at {} failed: {}", contract_path.display(), e);
             std::process::exit(1);
         }
     };


### PR DESCRIPTION
This pull request introduces a new `runner` module to standardize and simplify CLI command execution, error handling, and output rendering. It refactors the main CLI command handler to use these new helpers, resulting in more consistent error messages and less repetitive code. Additionally, it updates error messages in the `prompt` command for consistency.

**CLI command execution and error handling improvements:**

* Introduced the `runner` module (`src/cli/runner.rs`) containing generic helpers for running usecases, printing command headers, handling failures, and writing output in a consistent, product-agnostic way. [[1]](diffhunk://#diff-adf8c21554506f9df622370f7f6188433ab9a69468eb1c1564994c1e7280d298R1-R105) [[2]](diffhunk://#diff-82453e80e064c58b8fe1569389172f4a10adc0e685de6c3a787e07bcd9d98cffR4)
* Refactored `src/cli/commands/mod.rs` to use `runner` helpers (`run_usecase`, `exit_on_failure`, `print_command_header`, `write_output`) for all major commands, removing duplicated error handling and output logic. [[1]](diffhunk://#diff-38da8705fdf2662e3e19585f900ecaa4856c7edd07d6686cc3a7a8f829fd1653L2-R2) [[2]](diffhunk://#diff-38da8705fdf2662e3e19585f900ecaa4856c7edd07d6686cc3a7a8f829fd1653L50-R48) [[3]](diffhunk://#diff-38da8705fdf2662e3e19585f900ecaa4856c7edd07d6686cc3a7a8f829fd1653L97-R79) [[4]](diffhunk://#diff-38da8705fdf2662e3e19585f900ecaa4856c7edd07d6686cc3a7a8f829fd1653L106-R133) [[5]](diffhunk://#diff-38da8705fdf2662e3e19585f900ecaa4856c7edd07d6686cc3a7a8f829fd1653L178-R143)

**Error message consistency:**

* Updated error messages in `src/commands/prompt.rs` to use a consistent format (prefixing with `[!]` and using lowercase descriptions), improving clarity across CLI outputs. [[1]](diffhunk://#diff-1e4f2dc87c9050e8e420ee6107d32e8256ae8186f24a1b2cfa952d99faaaaf35L14-R22) [[2]](diffhunk://#diff-1e4f2dc87c9050e8e420ee6107d32e8256ae8186f24a1b2cfa952d99faaaaf35L31-R31) [[3]](diffhunk://#diff-1e4f2dc87c9050e8e420ee6107d32e8256ae8186f24a1b2cfa952d99faaaaf35L44-R41) [[4]](diffhunk://#diff-1e4f2dc87c9050e8e420ee6107d32e8256ae8186f24a1b2cfa952d99faaaaf35L65-R62)