### PR TITLE
docs: add layer responsibility guide and update refactor checklist references

### DIFF
--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -1,8 +1,8 @@
 # Current State: Architecture Rule Alignment
 
-Date: 2026-04-10
-Target issue: #202
-Reference: `ARCHITECTURE_RULES.md`
+Date: 2026-04-25
+Target issues: #202, #262
+Reference: `ARCHITECTURE_RULES.md`, `docs/architecture/layer-guide.md`
 
 ## Purpose
 
@@ -13,6 +13,8 @@ Reference: `ARCHITECTURE_RULES.md`
 This note verifies the current `src/` structure against our architecture rules and records the remaining gaps that should still guide refactoring and review.
 
 It replaces the earlier pre-refactor audit from issue #191 with a shorter "what is aligned now / what is still transitional" view.
+
+> **See also**: [`docs/architecture/layer-guide.md`](./layer-guide.md) for a contributor-facing module placement guide, placement decision flowchart, and boundary violation checklist.
 
 ## 1. Current structure snapshot
 
@@ -59,6 +61,12 @@ The following rule expectations are already reflected in the implementation:
 
 6. Structured application errors exist
 - Application-facing error types now exist instead of only ad hoc string errors.
+
+7. Shared CLI execution pipeline is formalized
+- `src/cli/runner.rs` provides generic `run_usecase`, `print_command_header`,
+  `exit_on_failure`, and `write_output` helpers.
+- Command arms for Init, Plan, Scaffold, Verify use the runner; legacy `commands/`
+  executors are not yet migrated.
 
 ## 3. Remaining gaps against the rules
 
@@ -128,10 +136,11 @@ Until the migration is complete, reviewers should treat architecture alignment a
 The next architecture-alignment wins are:
 
 1. Replace direct legacy config access with narrower app-facing loaders or ports where helpful.
-2. Keep shrinking `model` and `generator` toward domain/infra ownership.
-3. Introduce `shared/` only if a primitive is truly stable and cross-cutting.
-4. Move report rendering helpers from `commands/verify.rs` into `infra/` once a
-   `VerifyRendererAdapter` is introduced, completing the full `commands/` cleanup.
+2. Keep shrinking `model/` and `generator/` toward domain/infra ownership (see `layer-guide.md` for migration directions).
+3. Back legacy `commands/` executors (`audit`, `fix`, `triage`, `prompt`, etc.) with `app/usecase/` modules one at a time.
+4. Introduce `shared/` only if a primitive is truly stable and cross-cutting.
+5. Move report rendering helpers from `commands/verify.rs` into `infra/rendering/` as a `VerifyRendererAdapter`.
+6. Move `generator/resolver.rs` path resolution rules into `domain/generation/`.
 
 ## 6. Status summary
 
@@ -140,3 +149,5 @@ The next architecture-alignment wins are:
 - [x] remaining gaps identified
 - [x] review interpretation recorded for future PRs
 - [x] app/usecase layer owns orchestration for init, plan, scaffold, verify (#260)
+- [x] cli/runner.rs introduced as shared execution pipeline (#261)
+- [x] layer responsibilities and placement guide documented (#262) → `layer-guide.md`

--- a/docs/architecture/layer-guide.md
+++ b/docs/architecture/layer-guide.md
@@ -1,0 +1,272 @@
+# Layer Responsibilities: Batonel Module Placement Guide
+
+> **Audience**: All contributors (human and AI).  
+> **Purpose**: Make placement decisions predictable. When you are unsure where a new
+> type, function, or file belongs, start here.
+
+---
+
+## Quick-Reference Table
+
+| Layer | Main question it answers | Allowed to depend on |
+|---|---|---|
+| `cli/` | How does the user invoke this from a terminal? | `app`, `infra` (for rendering), `cli::runner` |
+| `app/` | In what order do we carry out this workflow? | `domain`, `ports` |
+| `domain/` | What are the rules and what decision do we make? | nothing outside `domain/` |
+| `ports/` | What capability boundary do we need? | nothing — traits only |
+| `infra/` | How do we actually read, write, or call the outside world? | `ports`, `domain` (data shapes only) |
+| `config/` | How do we load and validate raw YAML/JSON config files? | `model/` data shapes, `serde`, `std::fs` |
+| `model/` | What are the shared data shapes and validation rules? | nothing outside `model/` |
+| `generator/` | How do we resolve paths and write scaffolded files? | `model/`, `config/`, `std::fs` |
+| `commands/` | *(Transitional)* Legacy command executors. Shrink; do not grow. | anything — but this is the debt |
+
+---
+
+## Layer Responsibilities
+
+### `cli/` — Terminal Adapter
+
+**Owns:**
+- CLI argument parsing (`clap` types, `#[command]`, `#[arg]`)
+- Input → Input-DTO translation
+- UseCase invocation via `cli::runner` helpers
+- Rendering usecase output to the terminal
+
+**Does not own:**
+- Business rules of any kind
+- File I/O (except bootstrapping `--config` path resolution)
+- Direct calls to `infra` adapters when a usecase exists
+
+**Where new code goes:**
+- New `--flag` or subcommand → `cli/mod.rs`
+- New rendering for a usecase output → add a handler arm in `cli/commands/mod.rs`
+- Shared execution plumbing (error exit, banner) → `cli/runner.rs`
+
+---
+
+### `app/` — Application Orchestration
+
+**Owns:**
+- UseCase structs (`*UseCase::execute`)
+- Input / Output DTO types (`*Input`, `*Output`)
+- Workflow sequencing (call domain A, then domain B, then write via port C)
+- Application-level error types (`AppError`, `ConfigLoadError`, …)
+
+**Does not own:**
+- Business rules (belongs in `domain/`)
+- Raw file I/O (belongs in `infra/` behind a port)
+- Terminal presentation (belongs in `cli/` or `infra/rendering/`)
+
+**Where new code goes:**
+- New user-facing workflow → new file in `app/usecase/`
+- New application error variant → `app/error.rs`
+
+---
+
+### `domain/` — Business Logic Core
+
+**Owns:**
+- Core concepts and models (`ProjectContext`, `ArchitecturePlan`, `GenerationPlan`, …)
+- Rule evaluation (`ArchitectureValidator`, `ArchitecturePlanner`, …)
+- Invariant checks
+- Preset resolution logic
+- All logic that answers "what is the correct decision?"
+
+**Does not own:**
+- File reading or writing (`std::fs`)
+- Shell / process execution
+- HTTP / network calls
+- Terminal formatting or ANSI color
+- `clap`, `tokio`, `reqwest`, or any I/O framework
+
+**Test rule:** Every `domain/` function must be testable without touching the
+filesystem, network, or shell.
+
+**Where new code goes:**
+- New business rule or decision → extend the relevant `domain/<concept>/` module
+- New cross-cutting domain concept → new subdirectory under `domain/`
+
+---
+
+### `ports/` — Capability Boundaries
+
+**Owns:**
+- Rust `trait` definitions for external capabilities
+- `OutputPort`, `FilesystemPort`, `GitPort`, `TemplatePort`, `LlmPort`
+
+**Does not own:**
+- Any implementation (that lives in `infra/`)
+- Business rules
+
+**Design rule:** Keep each port focused on one capability. Avoid "god ports".
+
+**Where new code goes:**
+- New external capability needed by `app/` → new trait in `ports/<capability>.rs`
+
+---
+
+### `infra/` — Concrete Adapters
+
+**Owns:**
+- Implementations of `ports/` traits
+- `ConsoleOutputAdapter`, `LocalFilesystemAdapter`, `PlanRendererAdapter`, etc.
+- Third-party error → internal error conversion
+
+**Does not own:**
+- Business decisions
+- Orchestration logic
+
+**Where new code goes:**
+- New implementation of an existing port → add to the matching `infra/` file
+- New rendering format → `infra/rendering/`
+
+---
+
+### `config/` — Raw Configuration Loading *(Transitional)*
+
+**Owns:**
+- YAML/JSON deserialization structs (`ProjectConfig`, `PlacementRulesConfig`, …)
+- Schema validation at parse time (`SUPPORTED_PROJECT_SCHEMA_VERSION`, duplicate checks)
+- Override policy resolution (`config/override_policy.rs`)
+- RBAC policy loading (`config/rbac.rs`)
+
+**Does not own:**
+- Business decisions about the loaded data (belongs in `domain/` or `app/`)
+- Terminal output
+
+**Boundary rule:** Config structs may be passed into `domain/` functions, but raw
+config parsing **must not** happen inside domain or app. The calling use case is
+responsible for loading config first, then handing the result to domain.
+
+**Migration direction:** As modules mature, the "semantic" meaning of each config
+field should migrate to domain types; only the raw deserialization shell should remain
+in `config/`.
+
+---
+
+### `model/` — Shared Data Shapes and Validation *(Transitional)*
+
+**Currently owns:**
+- Lightweight value types: `Artifact`, `Contract`, `Placement`, `Project`
+- Validation logic tightly coupled to these shapes: `contract_validation`,
+  `prompt_validation`, `scaffold_validation`, `status_validation`
+- The `verify` report model (`VerifyReport`, `CheckResult`, `VerifyStatus`)
+
+**Ambiguity note:** `model/` sits between `config/` (raw) and `domain/` (decisions).
+The value types here are candidates for migration into `domain/` sub-modules as the
+relevant domain areas mature.
+
+**Rule for new code:** Do not add new *business decision logic* to `model/`. If you
+need to validate or evaluate something, ask: does it belong in a named `domain/<area>`
+module instead?
+
+---
+
+### `generator/` — Scaffold File Generation *(Transitional)*
+
+**Currently owns:**
+- Artifact path resolution (`generator/resolver.rs`)
+- File template rendering and writing (`generator/scaffold.rs`)
+
+**Ambiguity note:** Path resolution is a domain concern (rules about where files go),
+while file writing is an infra concern (actually touching the filesystem). These two
+responsibilities should eventually separate into `domain/generation/` (rules) and
+`infra/` (writes).
+
+**Rule for new code:** Do not add new business rules here. Path resolution rules
+belong in `domain/generation/`; file writing belongs behind a `FilesystemPort`.
+
+---
+
+### `commands/` — Legacy CLI Executors *(Transitional)*
+
+**Status:** Being phased out. `commands/init.rs` and `commands/scaffold.rs` are
+stubs. `commands/verify.rs` is a rendering helper only.
+
+**Rule:** Do not add new orchestration here. Any new command must be backed by a
+`app/usecase/` module. Legacy executors that remain (`audit`, `fix`, `prompt`,
+`triage`, `guard`, `compliance_report`, `fix_rollout`, `policy_resolve`,
+`preset_migrate`, `preset_registry`, `preset_verify`) should shrink over time.
+
+---
+
+## Placement Decision Guide
+
+Use this flowchart when you are unsure where to put new code.
+
+```
+Is this about parsing or loading a YAML/JSON file?
+  └─ YES → config/
+
+Is this a business rule, validation, or planning decision?
+  └─ YES → domain/<concept>/
+
+Is this orchestrating multiple domain calls and ports together?
+  └─ YES → app/usecase/
+
+Is this defining what an external capability looks like (a trait)?
+  └─ YES → ports/
+
+Is this implementing how we actually read/write/call something?
+  └─ YES → infra/
+
+Is this about parsing CLI arguments, rendering output, or mapping
+CLI input to a usecase?
+  └─ YES → cli/
+
+Is this a shared, stable, cross-cutting primitive with no better home?
+  └─ YES → shared/ (create if it does not exist; keep it tiny)
+```
+
+---
+
+## Common Change Types
+
+### "I need to add a new CLI flag"
+→ Add to `cli/mod.rs`. Map in `cli/commands/mod.rs`. Keep the handler arm thin.
+
+### "I need a new validation rule"
+→ Add to the relevant `domain/validation/` module. Write a unit test.
+
+### "I need to load a new config file"
+→ Add a deserialization struct in `config/`. Load it in the relevant `app/usecase/`.
+
+### "I need to write files to disk"
+→ Use `std::fs` in `generator/scaffold.rs` for now. Longer term, add a
+`FilesystemPort` method and implement it in `infra/`.
+
+### "I need a new rendering format"
+→ Add a method to `infra/rendering/`. Call it from the command arm in
+`cli/commands/mod.rs`.
+
+### "I need to add a new command end-to-end"
+1. Define Input/Output structs in `app/usecase/<name>.rs`.
+2. Implement `<Name>UseCase::execute`.
+3. Add the command variant in `cli/mod.rs`.
+4. Wire the arm in `cli/commands/mod.rs` using `runner::run_usecase`.
+
+---
+
+## Known Ambiguous / Leaky Areas
+
+| Area | Issue | Recommended direction |
+|---|---|---|
+| `model/` validation modules | Mix of data shapes and rule logic | Migrate decision logic to `domain/` sub-modules |
+| `generator/resolver.rs` | Path resolution rules live outside `domain/` | Move rule logic to `domain/generation/` |
+| `config/` loaded into `app/usecase/` directly | No port abstraction for config loading | Acceptable intermediate state; do not leak config types further |
+| `commands/verify.rs` rendering helpers | Rendering in `commands/` rather than `infra/` | Move to `infra/rendering/` as a `VerifyRendererAdapter` |
+| `commands/audit.rs` etc. | Full orchestration in `commands/` | Back with `app/usecase/` one at a time |
+
+---
+
+## Boundary Violation Checklist (for Code Review)
+
+- [ ] Does `domain/` import `clap`, `std::fs`, `reqwest`, or any shell-execution crate?
+- [ ] Does `domain/` call `std::process::exit`?
+- [ ] Does `cli/` contain branching logic that makes a business decision?
+- [ ] Does `infra/` define a business rule or domain invariant?
+- [ ] Does `app/` call `println!` or `eprintln!` directly?
+- [ ] Does `ports/` contain any `struct` implementation (not just `trait`)?
+- [ ] Was new code placed in `commands/`, `model/`, or `generator/` without a documented reason?
+
+If any of these is **yes**, the PR should explain why or offer a remediation plan.

--- a/docs/architecture/refactor-checklist.md
+++ b/docs/architecture/refactor-checklist.md
@@ -35,3 +35,11 @@ Before review:
 - [ ] Re-read `ARCHITECTURE_RULES.md` if the change crosses more than one layer
 - [ ] Update `docs/architecture/current-state.md` when the boundary picture materially changes
 - [ ] Call out any temporary architecture debt in the PR summary
+
+---
+
+## Reference
+
+- [Layer Responsibilities Guide](./layer-guide.md) — placement flowchart, per-layer rules, common change type recipes, and boundary violation review checklist.
+- [ARCHITECTURE_RULES.md](../ARCHITECTURE_RULES.ja.md) — full rule set (Japanese).
+- [current-state.md](./current-state.md) — current alignment status and remaining gaps.


### PR DESCRIPTION
This pull request improves the documentation around architecture layering and module placement. It introduces a new contributor-facing guide for deciding where new code should go, clarifies migration directions for transitional modules, and updates the current state and checklist docs to reference these new resources. The changes help make the architecture more understandable and maintainable for all contributors.

**Major documentation improvements:**

* Added a comprehensive `layer-guide.md` that explains the responsibilities and boundaries of each source directory, provides a placement decision flowchart, common change recipes, and a boundary violation checklist for code review.
* Updated `current-state.md` to reference the new `layer-guide.md`, clarify remaining migration steps, and document recent progress (e.g., introduction of `cli/runner.rs` and the placement guide). [[1]](diffhunk://#diff-5d9e4c7595a1bab3498c4e91da1c6dd4804e5b46b94fe83cec9e297bda91f66bL3-R5) [[2]](diffhunk://#diff-5d9e4c7595a1bab3498c4e91da1c6dd4804e5b46b94fe83cec9e297bda91f66bR17-R18) [[3]](diffhunk://#diff-5d9e4c7595a1bab3498c4e91da1c6dd4804e5b46b94fe83cec9e297bda91f66bR65-R70) [[4]](diffhunk://#diff-5d9e4c7595a1bab3498c4e91da1c6dd4804e5b46b94fe83cec9e297bda91f66bL131-R143) [[5]](diffhunk://#diff-5d9e4c7595a1bab3498c4e91da1c6dd4804e5b46b94fe83cec9e297bda91f66bR152-R153)

**Checklist and reference updates:**

* Added a "Reference" section to `refactor-checklist.md` pointing to the new layer guide, architecture rules, and current state documentation.