### PR TITLE
feat: implement integration test harness with CLI command tests and project fixtures

### DIFF
--- a/ARCHITECTURE_RULES.md
+++ b/ARCHITECTURE_RULES.md
@@ -450,6 +450,23 @@ These tests SHOULD use fakes or mocks for ports.
 
 ### Integration tests
 
+Batonel uses two distinct integration testing strategies:
+
+**1. Rust-native Integration Tests (`tests/`)**
+These tests compile the CLI binary and test it against a real filesystem using `assert_cmd` and `predicates`.
+They MUST be used for:
+- Main product flows (`init`, `plan`, `scaffold`, `verify`)
+- CLI argument parsing validation
+- Expected file modifications and stdout/stderr assertions
+- Deterministic failure paths for CLI commands
+
+**2. Shell Scripts (`scripts/`)**
+These are legacy or specialized tools that exist outside the core test harness.
+They SHOULD ONLY be used for:
+- End-to-end environment checks
+- CI workflow simulations (e.g. GitHub Actions testing)
+- Operations that require external tools (e.g. `git`, `ssh-keygen`, or ecosystem compliance benchmarks)
+
 May verify:
 - config loading
 - real filesystem interaction

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,19 @@ Before submitting a PR, please confirm:
 - schemas are updated if structure changes
 - decision records are reviewed if the change affects project direction
 
+### Testing
+
+Batonel relies on a mix of domain-level unit tests, application-level mock tests, and Rust-native integration tests.
+For detailed rules on when to write tests, see the Testing Rules section in `ARCHITECTURE_RULES.md`.
+
+When testing CLI flows (`batonel init`, `plan`, `scaffold`, `verify`), prefer adding tests to the Rust integration suite in `tests/` rather than creating new shell scripts. Shell scripts should be reserved for environment or ecosystem compliance checks.
+
+Run tests locally with:
+```bash
+cargo test
+cargo test --test cli  # For integration tests only
+```
+
 ### Commit and PR style
 
 Recommended style:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +77,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,8 +101,10 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 name = "batonel"
 version = "1.9.5"
 dependencies = [
+ "assert_cmd",
  "chrono",
  "clap",
+ "predicates",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -91,6 +117,17 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -180,6 +217,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +249,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "foldhash"
@@ -342,6 +394,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +419,36 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -395,6 +483,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"
@@ -520,6 +637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +685,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,5 @@ thiserror = "1.0"
 
 [dev-dependencies]
 tempfile = "3.27.0"
+assert_cmd = "2.0"
+predicates = "3.0"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,6 @@
+mod cli {
+    mod init;
+    mod plan;
+    mod scaffold;
+    mod verify;
+}

--- a/tests/cli/init.rs
+++ b/tests/cli/init.rs
@@ -1,0 +1,51 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn test_init_dry_run() {
+    let temp = TempDir::new().unwrap();
+
+    let mut cmd = Command::cargo_bin("batonel").unwrap();
+    cmd.current_dir(temp.path())
+        .arg("init")
+        .arg("--preset")
+        .arg("generic-layered")
+        .arg("--project-name")
+        .arg("test-project")
+        .arg("--dry-run");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("create project.baton.yaml"));
+        
+    // Since it's a dry run, the project file shouldn't be created
+    assert!(!temp.path().join("project.baton.yaml").exists());
+}
+
+#[test]
+fn test_init_success() {
+    let temp = TempDir::new().unwrap();
+
+    let mut cmd = Command::cargo_bin("batonel").unwrap();
+    cmd.current_dir(temp.path())
+        .arg("init")
+        .arg("--preset")
+        .arg("generic-layered")
+        .arg("--project-name")
+        .arg("test-project");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Generated project.baton.yaml"));
+
+    // Ensure the basic project file is created
+    let project_yaml = temp.path().join("project.baton.yaml");
+    assert!(project_yaml.exists());
+
+    // Verify the project name was injected correctly
+    let content = fs::read_to_string(&project_yaml).unwrap();
+    assert!(content.contains("test-project"));
+}
+

--- a/tests/cli/plan.rs
+++ b/tests/cli/plan.rs
@@ -1,0 +1,34 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::PathBuf;
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/valid_project")
+}
+
+#[test]
+fn test_plan_text_format() {
+    let mut cmd = Command::cargo_bin("batonel").unwrap();
+    cmd.current_dir(fixture_dir())
+        .arg("plan")
+        .arg("--format")
+        .arg("text");
+
+    cmd.assert()
+        .success()
+        // Text format often outputs "Plan" or the project name
+        .stdout(predicate::str::contains("minimal-app"));
+}
+
+#[test]
+fn test_plan_json_format() {
+    let mut cmd = Command::cargo_bin("batonel").unwrap();
+    cmd.current_dir(fixture_dir())
+        .arg("plan")
+        .arg("--format")
+        .arg("json");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("\"minimal-app\""));
+}

--- a/tests/cli/scaffold.rs
+++ b/tests/cli/scaffold.rs
@@ -1,0 +1,26 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+#[test]
+fn test_scaffold_success() {
+    let temp = TempDir::new().unwrap();
+    
+    // Seed project
+    let mut init_cmd = Command::cargo_bin("batonel").unwrap();
+    init_cmd.current_dir(temp.path())
+        .arg("init")
+        .arg("--preset")
+        .arg("generic-layered")
+        .arg("--project-name")
+        .arg("test-scaffold");
+    init_cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("batonel").unwrap();
+    cmd.current_dir(temp.path())
+        .arg("scaffold");
+
+    cmd.assert()
+        .success();
+}
+

--- a/tests/cli/verify.rs
+++ b/tests/cli/verify.rs
@@ -1,0 +1,29 @@
+use assert_cmd::Command;
+use std::path::PathBuf;
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/valid_project")
+}
+
+#[test]
+fn test_verify_success() {
+    let mut cmd = Command::cargo_bin("batonel").unwrap();
+    cmd.current_dir(fixture_dir())
+        .arg("verify");
+
+    cmd.assert()
+        .success();
+}
+
+#[test]
+fn test_verify_missing_project() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let mut cmd = Command::cargo_bin("batonel").unwrap();
+    
+    // Running in an empty directory should fail because project.baton.yaml is missing
+    cmd.current_dir(temp.path())
+        .arg("verify");
+
+    cmd.assert()
+        .failure();
+}

--- a/tests/fixtures/valid_project/artifacts.plan.yaml
+++ b/tests/fixtures/valid_project/artifacts.plan.yaml
@@ -1,0 +1,16 @@
+artifacts:
+  - name: create_user
+    module: user
+    role: usecase
+    status: planned
+    inputs:
+      - CreateUserCommand
+    outputs:
+      - CreateUserResult
+
+  - name: user
+    module: user
+    role: entity
+    status: planned
+    outputs:
+      - User

--- a/tests/fixtures/valid_project/contracts.template.yaml
+++ b/tests/fixtures/valid_project/contracts.template.yaml
@@ -1,0 +1,17 @@
+role_templates:
+  usecase:
+    responsibilities:
+      - "Execute one application use case"
+      - "Coordinate domain behavior"
+    must_not:
+      - "Access infrastructure details directly"
+      - "Return transport-specific responses"
+    implementation_size: "small"
+
+  entity:
+    responsibilities:
+      - "Represent a core business concept"
+      - "Protect domain invariants"
+    must_not:
+      - "Depend on transport or persistence details"
+    implementation_size: "small"

--- a/tests/fixtures/valid_project/guard.sidecar.yaml
+++ b/tests/fixtures/valid_project/guard.sidecar.yaml
@@ -1,0 +1,11 @@
+version: 1
+
+hooks:
+  init: true
+  plan: true
+  ci: true
+
+checks:
+  require_contracts_template: true
+  require_role_templates_for_artifact_roles: true
+  enforce_sidecar_suffixes: true

--- a/tests/fixtures/valid_project/placement.rules.yaml
+++ b/tests/fixtures/valid_project/placement.rules.yaml
@@ -1,0 +1,7 @@
+roles:
+  usecase:
+    path: "src/application/usecases/"
+    file_extension: rs
+  entity:
+    path: "src/domain/entities/"
+    file_extension: rs

--- a/tests/fixtures/valid_project/project.baton.yaml
+++ b/tests/fixtures/valid_project/project.baton.yaml
@@ -1,0 +1,13 @@
+batonel:
+  schema_version: "1"
+
+project:
+  name: minimal-app
+  architecture_style: simple
+  language: generic
+
+modules:
+  - name: user
+    features:
+      - create_user
+      - user_entity

--- a/tests/fixtures/valid_project/src/application/usecases/create_user.contract.yaml
+++ b/tests/fixtures/valid_project/src/application/usecases/create_user.contract.yaml
@@ -1,0 +1,9 @@
+name: create_user
+module: user
+role: usecase
+path: src/application/usecases/create_user.rs
+status: planned
+responsibilities:
+  - TODO
+must_not:
+  - TODO

--- a/tests/fixtures/valid_project/src/application/usecases/create_user.prompt.md
+++ b/tests/fixtures/valid_project/src/application/usecases/create_user.prompt.md
@@ -1,0 +1,1 @@
+<!-- Prompt override for: create_user (usecase) -->

--- a/tests/fixtures/valid_project/src/application/usecases/create_user.rs
+++ b/tests/fixtures/valid_project/src/application/usecases/create_user.rs
@@ -1,0 +1,1 @@
+// Batonel placeholder: create_user (usecase)

--- a/tests/fixtures/valid_project/src/domain/entities/user.contract.yaml
+++ b/tests/fixtures/valid_project/src/domain/entities/user.contract.yaml
@@ -1,0 +1,9 @@
+name: user
+module: user
+role: entity
+path: src/domain/entities/user.rs
+status: planned
+responsibilities:
+  - TODO
+must_not:
+  - TODO

--- a/tests/fixtures/valid_project/src/domain/entities/user.prompt.md
+++ b/tests/fixtures/valid_project/src/domain/entities/user.prompt.md
@@ -1,0 +1,1 @@
+<!-- Prompt override for: user (entity) -->

--- a/tests/fixtures/valid_project/src/domain/entities/user.rs
+++ b/tests/fixtures/valid_project/src/domain/entities/user.rs
@@ -1,0 +1,1 @@
+// Batonel placeholder: user (entity)


### PR DESCRIPTION
This pull request introduces a comprehensive Rust-native integration test suite for the Batonel CLI, formalizes testing guidelines in documentation, and adds new development dependencies to support the integration tests. The new tests cover main CLI flows (`init`, `plan`, `scaffold`, `verify`) using real filesystem operations and fixtures, ensuring robust validation of CLI behavior. Additionally, the documentation now clearly distinguishes when to use integration tests versus shell scripts, and provides updated guidance for contributors.

**Integration Test Suite Implementation:**

* Added a new `cli` module in `tests/cli.rs` with submodules for `init`, `plan`, `scaffold`, and `verify`, each containing integration tests for the corresponding CLI command. These tests use `assert_cmd`, `predicates`, and `tempfile` to validate CLI output and file system effects. [[1]](diffhunk://#diff-bcb711f1b6fb02677c65dec5c9027deaf435a7fc7b5191a8e25e7256d37773deR1-R6) [[2]](diffhunk://#diff-0cb98b6ae09b604cf5d5ceba6647eababbed12d86b51e87869c90af7c495754cR1-R51) [[3]](diffhunk://#diff-a0782b24f144329a7a4c04d89a03debb294228004a93583b76362a99be39707bR1-R34) [[4]](diffhunk://#diff-bad68919e9400b8dd32ce32f4898411a76c9006dd1dc63c25d9dcb9d5862a5eeR1-R26) [[5]](diffhunk://#diff-af292fdaa18e8e3650a4e91c4bcddd924d11db6cc4df7f3615739bf5e9196df0R1-R29)
* Introduced a comprehensive set of fixture files under `tests/fixtures/valid_project/` to support integration tests, simulating a minimal valid project structure and configuration. [[1]](diffhunk://#diff-26bcfa4035c1979b87264335011db2968261ff24123d98081d255bdf1195c2cdR1-R16) [[2]](diffhunk://#diff-56e4465b260d290ff63d7ef61dc1195a03faef648623a24fa54c9926d1e44fedR1-R17) [[3]](diffhunk://#diff-fbd8f2f144c07de59c7ca48378aa8002e21239ce6ce23e004830cb5ed5cc4ac3R1-R11) [[4]](diffhunk://#diff-0e84d89a0086de1ac326ded1793244f469ad18ab1e93a63e804c273f2ee3b847R1-R7) [[5]](diffhunk://#diff-5e4cd796846b0d71c5676976d06c18e858a35714a4ad76f1974ee08e2d4fb416R1-R13) [[6]](diffhunk://#diff-d3cc9e040b1da190928f9be99568b269cbf3e23dfea1f9fef3802773cce5db0eR1-R9) [[7]](diffhunk://#diff-fa56594ab93609dba1babc2664d6bd8306d13a5b2688dc5dfd32075bbb88a789R1) [[8]](diffhunk://#diff-e20e968f8adb8db741b0a07679af1add19f7904d557d9129163963bff5f22676R1) [[9]](diffhunk://#diff-fc97bd011e6c7f905b540f617185e83602fea3ce64b6c2de8ecd4a2dc7938cabR1-R9) [[10]](diffhunk://#diff-f7c0de85d689f69069d8e3ec94bbaf2fd2902c9e6922c61b045f33ab5e35a085R1) [[11]](diffhunk://#diff-c17cfbb46202138fb8427999369770f9096cd1e6ef605f6534a29b654431c0b7R1)

**Testing Infrastructure and Dependencies:**

* Added `assert_cmd` and `predicates` as development dependencies in `Cargo.toml` to enable expressive CLI assertions in tests.

**Documentation and Contributor Guidance:**

* Updated `ARCHITECTURE_RULES.md` to clarify the two integration testing strategies: Rust-native integration tests for core CLI flows and shell scripts for environment/CI checks, specifying when each should be used.
* Revised `CONTRIBUTING.md` to guide contributors on preferred testing approaches, emphasizing Rust integration tests for CLI flows and providing instructions for running tests locally.