### PR TITLE
docs: update release operations and acceptance criteria to include cryptographic signature artifacts and expanded blocking CI gates

### DIFF
--- a/docs/acceptance-criteria.md
+++ b/docs/acceptance-criteria.md
@@ -35,15 +35,27 @@ Batonel provides the following guarantees to users and contributors. These are a
 
 ---
 
-## 2. Release Gating
+## 2. Release Gating (The Release Contract)
 
-A release is considered "Gated" by these criteria. No official release of Batonel shall be published if any of the following workflows fail:
+A release is considered "Gated" by these criteria. No official release of Batonel shall be published if any of the following blocking workflows fail.
 
-1. **Batonel Verify Example** (G1)
-2. **Onboarding Init-Plan E2E** (G2)
-3. **Batonel Verify Parity** (G3)
+### Blocking Release Gates
+These checks are mandatory. A failure here explicitly prevents a release artifact from being published or trusted:
 
-For more details on the release process, see [docs/release-operations.md](./release-operations.md).
+1. **Tag Version Integrity** (`.github/workflows/verify-tag-version.yml`): Ensures the Git tag version strictly matches the `Cargo.toml` version.
+2. **Preset Trust & Signing** (`.github/workflows/preset-trust-verification.yml`): Validates cryptographic Ed25519 signatures of core presets using `scripts/verify_trust.sh`.
+3. **Core Verification Integrity** (`.github/workflows/batonel-verify-example.yml`): Verifies (G1).
+4. **Onboarding Determinism** (`.github/workflows/onboarding-init-plan-e2e.yml`): Verifies (G2) using `scripts/onboarding_e2e_init_plan.sh`.
+5. **Ecosystem Parity** (`.github/workflows/batonel-verify-parity.yml`): Verifies (G3) using `scripts/verify_parity.sh`.
+6. **Rust Native Integration Tests** (`cargo test --test cli`): Ensures core commands (`init`, `plan`, `scaffold`, `verify`) execute correctly against a real filesystem.
+
+### Non-Blocking / PR-Level Gates
+These checks act as advisory quality gates during PR review. While they are expected to pass on `main` for repository health, they do not technically block the creation of release artifacts:
+
+1. **Audit Baseline PR Gate** (`.github/workflows/batonel-audit-pr-gate.yml`): Verifies architectural compliance for the Batonel repository itself.
+2. **Guard Sidecar Checks** (`.github/workflows/batonel-guard-sidecar.yml`): Executes sidecar verifications explicitly.
+
+For more details on the release process and deliverables, see [docs/release-operations.md](./release-operations.md).
 
 ---
 

--- a/docs/release-operations.md
+++ b/docs/release-operations.md
@@ -13,6 +13,7 @@ Every release must publish all of the following assets on GitHub Releases:
 - `batonel-vX.Y.Z-aarch64-apple-darwin.tar.gz`
 - `*.sha256` for each archive
 - `checksums.txt` (combined checksum list)
+- `*.sig` (Ed25519 cryptographic signatures for the release archives, generated via the `sign-release-assets.yml` workflow)
 
 The release workflow is:
 
@@ -146,13 +147,16 @@ The generated release body describes all breaking changes from merged PR titles.
 
 Every release must pass the formal **Acceptance Criteria** defined in [docs/acceptance-criteria.md](./acceptance-criteria.md).
 
-The following CI workflows act as hard gates:
+The following CI workflows act as hard, blocking gates. If any of these fail, the release artifact must not be published:
 
-- **Batonel Verify Example**: Ensures core `verify` logic works on all standard examples.
-- **Onboarding Init-Plan E2E**: Ensures `init` and `plan` (determinism) work correctly for new projects.
-- **Batonel Verify Parity**: Ensures presets and examples stay synchronized.
+- **Tag Version Integrity**: Tag must match Cargo.toml version.
+- **Preset Trust & Signing**: Cryptographic verification of core presets.
+- **Batonel Verify Example**: Core `verify` logic works on standard examples.
+- **Onboarding Init-Plan E2E**: `init` and `plan` (determinism) work correctly.
+- **Batonel Verify Parity**: Presets and examples stay synchronized.
+- **Rust Native Integration Tests**: Primary CLI flows execute correctly.
 
-If any of these workflows fail, the release must be blocked until the root cause is resolved.
+For advisory, non-blocking PR gates (like Audit and Guard), refer to the full [Release Contract](./acceptance-criteria.md).
 
 ## 8. Verification checklist
 


### PR DESCRIPTION
This pull request updates the documentation to clarify and expand the release gating and artifact requirements for Batonel. It introduces more precise definitions of blocking and non-blocking release gates, details the CI workflows that must pass before a release, and adds a requirement for cryptographic signatures on release assets.

**Release gating and CI workflow documentation:**

* Expanded the "Release Gating" section in `docs/acceptance-criteria.md` to clearly distinguish between blocking (mandatory) and non-blocking (advisory) gates, listing specific CI workflows and their purposes, and referencing associated scripts and files.
* Updated `docs/release-operations.md` to list all required blocking CI workflows for a release, aligning with the new terminology and requirements from the acceptance criteria.

**Release artifact requirements:**

* Added a requirement in `docs/release-operations.md` that every release must include Ed25519 cryptographic signature files (`*.sig`) for each archive, generated by the `sign-release-assets.yml` workflow.