### PR TITLE
feat: implement automatic AI response parsing and secure file system writing for handoff commands

### DIFF
--- a/src/commands/handoff.rs
+++ b/src/commands/handoff.rs
@@ -8,8 +8,8 @@ pub fn execute(target: &str) {
     println!("Batonel Handoff Execution");
     println!("=========================");
 
-    let contract_path = if target.ends_with(".yaml") || target.ends_with(".yml") {
-        PathBuf::from(target)
+    let (contract_path, target_path) = if target.ends_with(".yaml") || target.ends_with(".yml") {
+        (PathBuf::from(target), None)
     } else {
         // Resolve target as an artifact name
         let placement_config = match PlacementRulesConfig::load("placement.rules.yaml") {
@@ -56,7 +56,7 @@ pub fn execute(target: &str) {
             "contract.yaml",
         );
 
-        contract_path
+        (contract_path, Some(path))
     };
 
     println!("  [i] Resolving contract from: {}", contract_path.display());
@@ -83,18 +83,71 @@ pub fn execute(target: &str) {
     
     let request = LlmRequest {
         prompt: prompt_text,
-        system_prompt: Some("You are an expert AI code generator. Generate code that exactly matches the provided architectural contracts.".to_string()),
+        system_prompt: Some("You are an expert AI code generator. Generate code that exactly matches the provided architectural contracts. Return ONLY the generated code wrapped in a single markdown code block.".to_string()),
         temperature: Some(0.2),
     };
 
     match llm_adapter.complete(&request) {
         Ok(response) => {
-            println!("{}", response.content);
-            println!("\n  [+] Handoff execution completed successfully.");
+            let extracted_code = crate::generator::ai_parser::AiResponseParser::extract_code_block(&response.content);
+            
+            if let Some(target_file) = target_path {
+                if !is_safe_to_write(&target_file) {
+                    eprintln!("[!] Security violation: Attempted to write to unsafe path: {}", target_file.display());
+                    std::process::exit(1);
+                }
+
+                if let Some(parent) = target_file.parent() {
+                    if let Err(e) = std::fs::create_dir_all(parent) {
+                        eprintln!("[!] failed to create directories for {}: {}", target_file.display(), e);
+                        std::process::exit(1);
+                    }
+                }
+
+                match std::fs::write(&target_file, &extracted_code) {
+                    Ok(_) => {
+                        println!("\n  [+] Handoff execution completed successfully.");
+                        println!("  [+] Code written to: {}", target_file.display());
+                    }
+                    Err(e) => {
+                        eprintln!("[!] failed to write to {}: {}", target_file.display(), e);
+                        std::process::exit(1);
+                    }
+                }
+            } else {
+                println!("{}", extracted_code);
+                println!("\n  [+] Handoff execution completed successfully. (No target path resolved, output printed to stdout)");
+            }
         }
         Err(e) => {
             eprintln!("[!] LLM handoff failed: {}", e);
             std::process::exit(1);
         }
     }
+}
+
+fn is_safe_to_write(path: &std::path::Path) -> bool {
+    let reserved = [
+        "project.baton.yaml",
+        "placement.rules.yaml",
+        "artifacts.plan.yaml",
+        "contracts.template.yaml",
+        "policy.profile.yaml",
+    ];
+
+    let path_str = path.to_string_lossy();
+    
+    // Disallow absolute paths and path traversal
+    if path.is_absolute() || path_str.contains("..") {
+        return false;
+    }
+
+    // Disallow overwriting Batonel core configs
+    for r in reserved {
+        if path_str.ends_with(r) {
+            return false;
+        }
+    }
+    
+    true
 }

--- a/src/generator/ai_parser.rs
+++ b/src/generator/ai_parser.rs
@@ -1,0 +1,104 @@
+//! AI Response Parsing Boundary
+//! 
+//! This module provides strict boundaries for how unstructured or semi-structured
+//! text responses from LLMs are parsed into safe, injectable code blocks.
+
+pub struct AiResponseParser;
+
+impl AiResponseParser {
+    /// Extracts the core code block from an AI response.
+    /// 
+    /// Standard AI responses often wrap the target code inside markdown code blocks,
+    /// e.g. ```rust ... ```. This function attempts to safely extract the longest
+    /// matching block of code. If no code block markers are found, it assumes the 
+    /// entire response is the code payload (raw mode).
+    pub fn extract_code_block(response_text: &str) -> String {
+        let mut blocks = Vec::new();
+        let mut in_block = false;
+        let mut current_block = String::new();
+
+        for line in response_text.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("```") {
+                if in_block {
+                    // End of block
+                    in_block = false;
+                    blocks.push(current_block.clone());
+                    current_block.clear();
+                } else {
+                    // Start of block
+                    in_block = true;
+                }
+                continue;
+            }
+
+            if in_block {
+                current_block.push_str(line);
+                current_block.push('\n');
+            }
+        }
+
+        // If we didn't find any closed markdown blocks, return the whole text, trimmed
+        if blocks.is_empty() {
+            return response_text.trim().to_string();
+        }
+
+        // Return the largest block found (heuristically, this is usually the main artifact code)
+        // rather than small snippets of configuration or bash commands.
+        blocks.into_iter()
+            .max_by_key(|b| b.len())
+            .unwrap_or_default()
+            .trim_end()
+            .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_code_block_from_markdown() {
+        let ai_response = "\
+Here is your requested code:
+
+```rust
+fn example() {
+    println!(\"Hello World\");
+}
+```
+
+Hope this helps!
+";
+        let extracted = AiResponseParser::extract_code_block(ai_response);
+        assert_eq!(extracted, "fn example() {\n    println!(\"Hello World\");\n}");
+    }
+
+    #[test]
+    fn test_extract_largest_code_block() {
+        let ai_response = "\
+Here is a small snippet:
+```rust
+use std::fs;
+```
+And here is the main implementation:
+```rust
+fn example() {
+    let mut i = 0;
+    while i < 10 {
+        i += 1;
+    }
+}
+```
+";
+        let extracted = AiResponseParser::extract_code_block(ai_response);
+        assert_eq!(extracted, "fn example() {\n    let mut i = 0;\n    while i < 10 {\n        i += 1;\n    }\n}");
+    }
+
+    #[test]
+    fn test_fallback_to_raw_text() {
+        let ai_response = "fn raw_function() {\n    println!(\"No markdown blocks\");\n}";
+        let extracted = AiResponseParser::extract_code_block(ai_response);
+        assert_eq!(extracted, "fn raw_function() {\n    println!(\"No markdown blocks\");\n}");
+    }
+}

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -1,5 +1,6 @@
 pub mod resolver;
 pub mod scaffold;
+pub mod ai_parser;
 
 #[allow(unused_imports)]
 pub use resolver::resolve_artifact_path;


### PR DESCRIPTION
This pull request enhances the safety and reliability of AI-generated code handoff by introducing a robust code block extraction utility, improving output handling, and adding safeguards to prevent accidental overwriting of critical configuration files. The changes primarily affect how AI responses are parsed and how the resulting code is written to disk.

**AI response parsing and output handling:**

* Introduced a new `AiResponseParser` utility in `src/generator/ai_parser.rs` to safely extract the largest code block from AI responses, falling back to the raw response if no markdown code blocks are found. This includes comprehensive tests for various response formats.
* Updated the handoff execution logic in `src/commands/handoff.rs` to use `AiResponseParser::extract_code_block`, ensuring only the intended code is output or written to disk.
* Modified the system prompt sent to the AI to instruct it to return only the generated code within a single markdown code block, reducing the chance of extraneous output.

**File output safety improvements:**

* Added logic to determine whether to write the generated code to a file or print to stdout, based on how the target is specified. [[1]](diffhunk://#diff-5907a045234366f1b8e6d8634cbaa6e9c08bf7287974ec9c2c430f7105eaf82dL11-R12) [[2]](diffhunk://#diff-5907a045234366f1b8e6d8634cbaa6e9c08bf7287974ec9c2c430f7105eaf82dL59-R59)
* Implemented an `is_safe_to_write` function to prevent writing to unsafe paths (e.g., absolute paths, path traversal, or Batonel core config files), and to ensure necessary directories are created before writing.

**Module organization:**

* Registered the new `ai_parser` module in `src/generator/mod.rs`.