### PR TITLE
feat: embed preset files in binary and update preset resolution logic to support embedded and XDG locations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "chrono",
  "clap",
  "predicates",
+ "rust-embed",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -117,6 +118,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -217,10 +227,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "equivalent"
@@ -264,6 +303,16 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -514,6 +563,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +620,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -598,6 +690,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -663,6 +766,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,12 +796,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -790,6 +915,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 chrono = "0.4"
 thiserror = "1.0"
+rust-embed = "8.0"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/src/app/usecase/init_project.rs
+++ b/src/app/usecase/init_project.rs
@@ -4,6 +4,11 @@ use std::path::{Path, PathBuf};
 use serde_yaml::{Mapping, Value};
 
 use crate::config::project::SUPPORTED_PROJECT_SCHEMA_VERSION;
+use rust_embed::RustEmbed;
+
+#[derive(RustEmbed)]
+#[folder = "presets/"]
+struct PresetAssets;
 
 // ---------------------------------------------------------------------------
 // Action types
@@ -323,33 +328,36 @@ checks:
     .to_string()
 }
 
-fn collect_preset_files(preset_id: &str) -> Result<Vec<(String, String)>, String> {
-    let preset_dir = match find_preset_dir(preset_id) {
-        Some(path) => path,
-        None => {
-            let available = list_available_presets();
-            let hint = if available.is_empty() {
-                "No presets are currently available under presets/".to_string()
-            } else {
-                format!("Available presets: {}", available.join(", "))
-            };
-            return Err(format!("Preset '{}' was not found. {}", preset_id, hint));
+fn load_preset_file(preset_id: &str, filename: &str) -> Result<String, String> {
+    // 1. Check local fs custom paths first
+    for root in preset_roots() {
+        let path = root.join(preset_id).join(filename);
+        if path.exists() {
+            return fs::read_to_string(&path)
+                .map_err(|e| format!("Failed to read custom preset file {}: {}", path.display(), e));
         }
-    };
+    }
 
-    if !preset_dir.exists() {
-        let available = list_available_presets();
+    // 2. Fall back to embedded presets
+    let asset_path = format!("{}/{}", preset_id, filename);
+    if let Some(file) = PresetAssets::get(&asset_path) {
+        if let Ok(content) = std::str::from_utf8(file.data.as_ref()) {
+            return Ok(content.to_string());
+        }
+    }
+
+    Err(format!("File '{}' not found in preset '{}'", filename, preset_id))
+}
+
+fn collect_preset_files(preset_id: &str) -> Result<Vec<(String, String)>, String> {
+    let available = list_available_presets();
+    if !available.contains(&preset_id.to_string()) {
         let hint = if available.is_empty() {
-            "No presets are currently available under presets/".to_string()
+            "No presets are currently available.".to_string()
         } else {
             format!("Available presets: {}", available.join(", "))
         };
-        return Err(format!(
-            "Preset '{}' was not found at {}. {}",
-            preset_id,
-            preset_dir.display(),
-            hint
-        ));
+        return Err(format!("Preset '{}' was not found. {}", preset_id, hint));
     }
 
     let mut files = Vec::new();
@@ -358,31 +366,18 @@ fn collect_preset_files(preset_id: &str) -> Result<Vec<(String, String)>, String
         "placement.rules.yaml",
         "contracts.template.yaml",
     ];
+    
     for filename in required {
-        let source = preset_dir.join(filename);
-        let contents = fs::read_to_string(&source).map_err(|e| {
-            format!(
-                "Failed to read required preset file {}: {}",
-                source.display(),
-                e
-            )
-        })?;
+        let contents = load_preset_file(preset_id, filename)?;
         files.push((filename.to_string(), contents));
     }
 
     let optional = ["artifacts.plan.yaml", "policy.profile.yaml", "guard.sidecar.yaml"];
     let mut has_policy_profile = false;
     let mut has_guard_sidecar = false;
+    
     for filename in optional {
-        let source = preset_dir.join(filename);
-        if source.exists() {
-            let contents = fs::read_to_string(&source).map_err(|e| {
-                format!(
-                    "Failed to read optional preset file {}: {}",
-                    source.display(),
-                    e
-                )
-            })?;
+        if let Ok(contents) = load_preset_file(preset_id, filename) {
             files.push((filename.to_string(), contents));
             if filename == "policy.profile.yaml" {
                 has_policy_profile = true;
@@ -411,6 +406,17 @@ fn collect_preset_files(preset_id: &str) -> Result<Vec<(String, String)>, String
 
 fn list_available_presets() -> Vec<String> {
     let mut presets = BTreeSet::new();
+    
+    // Check embedded presets
+    for file in PresetAssets::iter() {
+        if let Some(preset_name) = file.split('/').next() {
+            if preset_name != "." {
+                presets.insert(preset_name.to_string());
+            }
+        }
+    }
+
+    // Check local filesystem
     for root in preset_roots() {
         if let Ok(entries) = fs::read_dir(root) {
             for entry in entries.flatten() {
@@ -425,21 +431,23 @@ fn list_available_presets() -> Vec<String> {
     presets.into_iter().collect()
 }
 
-fn find_preset_dir(preset_id: &str) -> Option<PathBuf> {
-    for root in preset_roots() {
-        let candidate = root.join(preset_id);
-        if candidate.is_dir() {
-            return Some(candidate);
+fn preset_roots() -> Vec<PathBuf> {
+    let mut roots = vec![
+        PathBuf::from("presets"), // local dev override
+    ];
+
+    if let Ok(env_dir) = std::env::var("BATONEL_PRESET_DIR") {
+        roots.push(PathBuf::from(env_dir));
+    } else {
+        // XDG Default
+        if let Ok(xdg_data_home) = std::env::var("XDG_DATA_HOME") {
+            roots.push(PathBuf::from(xdg_data_home).join("batonel").join("presets"));
+        } else if let Ok(home) = std::env::var("HOME") {
+            roots.push(PathBuf::from(home).join(".local").join("share").join("batonel").join("presets"));
         }
     }
-    None
-}
 
-fn preset_roots() -> Vec<PathBuf> {
-    vec![
-        PathBuf::from("presets"),
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("presets"),
-    ]
+    roots
 }
 
 fn ensure_project_arch_metadata(contents: &str, preset: Option<&str>) -> Result<String, String> {


### PR DESCRIPTION
This pull request introduces support for embedding preset files directly into the binary using the `rust-embed` crate, while still allowing for local and environment-based overrides. The changes refactor how preset files are loaded and discovered, enabling a more flexible and robust preset management system.

**Preset Embedding and Loading Enhancements:**

* Added the `rust-embed` dependency and defined the `PresetAssets` struct to embed files from the `presets/` directory into the binary. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R16) [[2]](diffhunk://#diff-3aa2f8ee564f7f2236ba78a990a727b5a44b8cd1e35ad101e27d9294c8012a51R7-R11)
* Refactored the preset file loading logic: `collect_preset_files` and related functions now first check for local or environment-provided preset files, and fall back to embedded assets if not found. [[1]](diffhunk://#diff-3aa2f8ee564f7f2236ba78a990a727b5a44b8cd1e35ad101e27d9294c8012a51L326-R360) [[2]](diffhunk://#diff-3aa2f8ee564f7f2236ba78a990a727b5a44b8cd1e35ad101e27d9294c8012a51R369-R380)

**Preset Discovery Improvements:**

* Updated `list_available_presets` to include both embedded and filesystem-based presets, ensuring all available presets are discoverable regardless of their source.
* Refactored `preset_roots` to support XDG and environment-based preset directories, and removed the old `find_preset_dir` logic for a more streamlined approach.

These changes make preset management more flexible and robust, supporting both embedded and external presets with a clear precedence order.