### PR TITLE
feat: implement drift detection command to validate implementation code against architectural contracts

### DIFF
--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -152,6 +152,9 @@ pub fn handle(command: Commands) {
         Commands::Handoff { target } => {
             crate::commands::handoff::execute(&target);
         }
+        Commands::Drift { target } => {
+            crate::commands::drift::execute(target.as_deref());
+        }
         Commands::Triage { top, json } => {
             crate::commands::triage::execute(top, json);
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -93,6 +93,12 @@ pub enum Commands {
         /// The artifact name or path to the .contract.yaml file
         target: String,
     },
+    /// [Advanced] Detect drift between implementation code and architectural contracts
+    Drift {
+        /// The artifact name to check for drift. If omitted, checks all artifacts.
+        #[arg(long)]
+        target: Option<String>,
+    },
     /// [Advanced] Triage audit violations by priority and generate a prioritized remediation plan
     Triage {
         /// Limit output to the top N remediation groups

--- a/src/commands/drift.rs
+++ b/src/commands/drift.rs
@@ -1,0 +1,149 @@
+use crate::config::{ArtifactsPlanConfig, PlacementRulesConfig};
+use crate::ports::{LlmPort, LlmRequest};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct DriftResult {
+    has_drift: bool,
+    deviations: Vec<String>,
+}
+
+pub fn execute(target: Option<&str>) {
+    println!("Batonel Continuous Alignment (Drift Detection)");
+    println!("==============================================");
+
+    let placement_config = match PlacementRulesConfig::load("placement.rules.yaml") {
+        Ok(config) => config,
+        Err(e) => {
+            eprintln!("[!] loading placement rules failed: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let artifacts_config = match ArtifactsPlanConfig::load("artifacts.plan.yaml") {
+        Ok(config) => config,
+        Err(e) => {
+            eprintln!("[!] loading artifacts plan failed: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let artifacts: Vec<_> = if let Some(t) = target {
+        artifacts_config.artifacts.into_iter().filter(|a| a.name == t).collect()
+    } else {
+        artifacts_config.artifacts
+    };
+
+    if artifacts.is_empty() {
+        if let Some(t) = target {
+            eprintln!("[!] artifact '{}' not found in artifacts.plan.yaml", t);
+            std::process::exit(1);
+        } else {
+            println!("No artifacts to check.");
+            return;
+        }
+    }
+
+    let llm_adapter = crate::infra::llm::DummyLlmAdapter;
+    let mut total_drift = 0;
+
+    for artifact in artifacts {
+        println!("\n[i] Checking artifact: {}", artifact.name);
+        
+        let path = match crate::generator::resolver::resolve_artifact_path(&artifact, &placement_config) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("  [!] skipping: resolving artifact path failed: {}", e);
+                continue;
+            }
+        };
+
+        if !path.exists() {
+            println!("  [-] Implementation not found at {}", path.display());
+            continue;
+        }
+
+        let role_config = placement_config.roles.get(&artifact.role);
+        let contract_path = crate::generator::resolver::resolve_sidecar_path(
+            &artifact,
+            &path,
+            role_config.and_then(|r| r.sidecar.as_ref().and_then(|s| s.contract_dir.as_deref())),
+            "contract.yaml",
+        );
+
+        if !contract_path.exists() {
+            println!("  [-] Contract not found at {}", contract_path.display());
+            continue;
+        }
+
+        let code_content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("  [!] failed to read implementation code: {}", e);
+                continue;
+            }
+        };
+
+        let contract_content = match std::fs::read_to_string(&contract_path) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("  [!] failed to read contract: {}", e);
+                continue;
+            }
+        };
+
+        let prompt = format!(
+            "You are an expert architecture validator.\n\
+            Evaluate whether the following implementation code correctly fulfills the responsibilities and adheres to the must_not constraints defined in the architectural contract.\n\n\
+            Contract:\n{}\n\n\
+            Implementation Code:\n{}\n",
+            contract_content,
+            code_content
+        );
+
+        let system_prompt = "You are an expert architecture validator. Respond ONLY with a JSON object in this exact format:\n\
+            {\n  \"has_drift\": true/false,\n  \"deviations\": [\"Explain any deviations or violations found. If has_drift is false, leave this array empty.\"]\n}";
+
+        let request = LlmRequest {
+            prompt,
+            system_prompt: Some(system_prompt.to_string()),
+            temperature: Some(0.0),
+        };
+
+        println!("  [~] Handing off to LLM for drift analysis...");
+        
+        match llm_adapter.complete(&request) {
+            Ok(response) => {
+                let extracted_json = crate::generator::ai_parser::AiResponseParser::extract_code_block(&response.content);
+                match serde_json::from_str::<DriftResult>(&extracted_json) {
+                    Ok(result) => {
+                        if result.has_drift {
+                            println!("  [!] Drift Detected!");
+                            for dev in result.deviations {
+                                println!("      - {}", dev);
+                            }
+                            total_drift += 1;
+                        } else {
+                            println!("  [+] Alignment Verified: Code adheres to the contract.");
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("  [!] failed to parse LLM drift analysis response: {}", e);
+                        eprintln!("      Raw extracted response: {}", extracted_json);
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("  [!] LLM analysis failed: {}", e);
+            }
+        }
+    }
+
+    println!();
+    if total_drift > 0 {
+        eprintln!("[!] Drift analysis complete. {} artifact(s) drifted from their contracts.", total_drift);
+        std::process::exit(1);
+    } else {
+        println!("[+] Drift analysis complete. All checked artifacts are aligned.");
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,3 +12,4 @@ pub mod preset_registry;
 pub mod preset_verify;
 pub mod prompt;
 pub mod verify;
+pub mod drift;

--- a/src/infra/llm.rs
+++ b/src/infra/llm.rs
@@ -26,8 +26,19 @@ impl crate::ports::LlmPort for DummyLlmAdapter {
             request.prompt.replace('\n', " ")
         };
         
+        let content = if request.system_prompt.as_deref().unwrap_or("").contains("JSON") {
+            r#"```json
+{
+  "has_drift": true,
+  "deviations": ["Mock drift detected in tests"]
+}
+```"#.to_string()
+        } else {
+            format!("Mock LLM Response generated for prompt:\n> {}\n\n```rust\n// AI-generated code based on contracts\nfn hello_ai() {{\n    println!(\"Successfully parsed contracts and generated code!\");\n}}\n```\n", preview)
+        };
+
         Ok(crate::ports::LlmResponse {
-            content: format!("Mock LLM Response generated for prompt:\n> {}\n\n```rust\n// AI-generated code based on contracts\nfn hello_ai() {{\n    println!(\"Successfully parsed contracts and generated code!\");\n}}\n```\n", preview)
+            content
         })
     }
 }


### PR DESCRIPTION
This pull request introduces a new "drift" detection feature to the CLI tool, allowing users to check for architectural drift between implementation code and contract definitions. The main changes add a new `drift` command, its implementation, and supporting logic for LLM-based drift analysis.

**New Drift Detection Feature:**

* CLI now supports a `drift` command to detect misalignment ("drift") between code and architectural contracts, optionally scoped to a specific artifact. [[1]](diffhunk://#diff-82453e80e064c58b8fe1569389172f4a10adc0e685de6c3a787e07bcd9d98cffR96-R101) [[2]](diffhunk://#diff-38da8705fdf2662e3e19585f900ecaa4856c7edd07d6686cc3a7a8f829fd1653R155-R157)
* Added `src/commands/drift.rs` with logic to:
  * Load artifacts and placement configs,
  * Resolve artifact and contract paths,
  * Use an LLM to analyze code vs. contract,
  * Parse and display drift results, and
  * Exit with error if drift is found.
* Registered the new `drift` command module.

**Testing and LLM Integration:**

* Updated the `DummyLlmAdapter` to return mock JSON drift results when the system prompt requests JSON, enabling easier testing of the drift analysis flow.